### PR TITLE
Refactoring the CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ dist: bionic
 # we test against Java 10 and 11 by default
 # Java 8 might be too old, but we can always include it into our build matrix
 jdk:
+  - openjdk8
   - openjdk10
   - openjdk11
 

--- a/cloud.foundry.cli/build.gradle
+++ b/cloud.foundry.cli/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     compile 'org.cloudfoundry:cloudfoundry-operations:4.6.0.RELEASE'
 
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
+
+    // fix annoying error by including missing dependency
+    // see http://www.slf4j.org/codes.html#StaticLoggerBinder
+    compile 'org.slf4j:slf4j-simple:1.7.+'
 }
 
 test {

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -3,6 +3,8 @@ package cloud.foundry.cli.services;
 import picocli.CommandLine.Command;
 import picocli.CommandLine;
 
+import java.util.concurrent.Callable;
+
 /**
  * This class works as the entry point for the command line application.
  * Based on this entrypoint you can call subcommands depending on your use case.
@@ -14,12 +16,13 @@ import picocli.CommandLine;
         subcommands = {
         CreateController.class,
         GetController.class})
-public class BaseController implements Runnable {
+public class BaseController implements Callable<Integer> {
 
     @Override
-    public void run() {
+    public Integer call() {
         // this code is executed if the user just runs the app
         CommandLine.usage(this, System.out);
+        return 0;
     }
 
     public static void main(String[] args) {

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -1,6 +1,7 @@
 package cloud.foundry.cli.services;
 
 import cloud.foundry.cli.crosscutting.exceptions.CreationException;
+import cloud.foundry.cli.crosscutting.exceptions.CredentialException;
 import cloud.foundry.cli.crosscutting.logging.Log;
 import picocli.CommandLine.Command;
 import picocli.CommandLine;
@@ -46,6 +47,8 @@ public class BaseController implements Callable<Integer> {
                 Log.error("Failed to create message:" + ex.getMessage());
             } else if (ex instanceof UnsupportedOperationException) {
                 Log.error("Operation not supported/implemented:", ex.getMessage());
+            } else if (ex instanceof CredentialException) {
+                Log.error("Credentials error:", ex.getMessage());
             } else if (ex instanceof IllegalStateException) {
                 // a little bit ugly, but it works
                 // the problem is in reactor.core.Exceptions

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/CreateController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/CreateController.java
@@ -18,8 +18,8 @@ import cloud.foundry.cli.operations.SpaceDevelopersOperations;
 import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * This class realizes the functionality that is needed for the create commands.
@@ -31,15 +31,16 @@ import java.util.Map;
                 CreateController.CreateServiceCommand.class,
                 CreateController.AssignSpaceDeveloperCommand.class,
                 CreateController.CreateApplicationCommand.class})
-public class CreateController implements Runnable {
+public class CreateController implements Callable<Integer> {
 
     @Override
-    public void run() {
+    public Integer call() {
         usage(this, System.out);
+        return 0;
     }
 
     @Command(name = "space-developer", description = "Assign users as space developers.")
-    static class AssignSpaceDeveloperCommand implements Runnable {
+    static class AssignSpaceDeveloperCommand implements Callable<Integer> {
 
         @Mixin
         LoginCommandOptions loginOptions;
@@ -48,32 +49,25 @@ public class CreateController implements Runnable {
         CreateControllerCommandOptions commandOptions;
 
         @Override
-        public void run() {
-            String yamlFileContent;
-            try {
-                yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
-            } catch (IOException e) {
-                Log.exception(e, "Failed to read YAML file");
-                return;
-            }
+        public Integer call() throws Exception {
+            String yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
+
             Yaml yamlLoader = YamlCreator.createDefaultYamlProcessor();
             SpaceDevelopersBean spaceDevelopersBean = yamlLoader.loadAs(yamlFileContent, SpaceDevelopersBean.class);
 
-            try {
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-                SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
 
-                for (String username : spaceDevelopersBean.getSpaceDevelopers()) {
-                    spaceDevelopersOperations.assignSpaceDeveloper(username);
-                }
-            } catch (Exception e) {
-                Log.exception(e, "Unexpected error occurred");
+            for (String username : spaceDevelopersBean.getSpaceDevelopers()) {
+                spaceDevelopersOperations.assignSpaceDeveloper(username);
             }
+
+            return 0;
         }
     }
 
     @Command(name = "service", description = "Create a service in the target space.")
-    static class CreateServiceCommand implements Runnable {
+    static class CreateServiceCommand implements Callable<Integer> {
 
         @Mixin
         LoginCommandOptions loginOptions;
@@ -82,35 +76,27 @@ public class CreateController implements Runnable {
         CreateControllerCommandOptions commandOptions;
 
         @Override
-        public void run() {
-            String yamlFileContent;
-            try {
-                yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
-            } catch (IOException e) {
-                Log.exception(e, "Failed to read YAML file");
-                return;
-            }
+        public Integer call() throws Exception {
+            String yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
+
             Yaml yamlLoader = YamlCreator.createDefaultYamlProcessor();
 
-            try {
+            Map<String, Object> mapServiceBean = yamlLoader.loadAs(yamlFileContent, Map.class);
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
 
-                Map<String, Object> mapServiceBean = yamlLoader.loadAs(yamlFileContent, Map.class);
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-
-                ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
-                for (String serviceInstanceName : mapServiceBean.keySet()) {
-                    String serviceBeanYaml = yamlLoader.dump(mapServiceBean.get(serviceInstanceName));
-                    ServiceBean serviceBean = yamlLoader.loadAs(serviceBeanYaml, ServiceBean.class);
-                    servicesOperations.create(serviceInstanceName, serviceBean);
-                }
-            } catch (Exception e) {
-                Log.exception(e, "Unexpected error occurred");
+            ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
+            for (String serviceInstanceName : mapServiceBean.keySet()) {
+                String serviceBeanYaml = yamlLoader.dump(mapServiceBean.get(serviceInstanceName));
+                ServiceBean serviceBean = yamlLoader.loadAs(serviceBeanYaml, ServiceBean.class);
+                servicesOperations.create(serviceInstanceName, serviceBean);
             }
+
+            return 0;
         }
     }
 
     @Command(name = "application", description = "Create a application in the target space.")
-    static class CreateApplicationCommand implements Runnable {
+    static class CreateApplicationCommand implements Callable<Integer> {
 
         @Mixin
         LoginCommandOptions loginOptions;
@@ -119,12 +105,13 @@ public class CreateController implements Runnable {
         CreateControllerCommandOptions commandOptions;
 
         @Override
-        public void run() {
-
-            try {
+        public Integer call() throws Exception {
                 String yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
+
                 Yaml yamlProcessor = YamlCreator.createDefaultYamlProcessor();
+
                 Map<String, Object> appMap = yamlProcessor.loadAs(yamlFileContent, Map.class);
+
                 if (appMap.entrySet().iterator().hasNext()) {
                     Map.Entry<String, Object> appObj = appMap.entrySet().iterator().next();
                     String name = appObj.getKey();
@@ -136,17 +123,11 @@ public class CreateController implements Runnable {
 
                     applicationOperations.create(name, applicationBean, false);
                     Log.info("App created:", name);
+                    return 0;
                 }
-                Log.error("App entry in the yaml input file has not a valid format or was missing");
-            } catch (IOException e) {
-                Log.exception(e, "Failed to read YAML file");
-                return;
-            } catch (CreationException e) {
-                Log.error("Failed to create message:" + e.getMessage());
-            } catch (Exception e) {
-                Log.exception(e, "Unexpected error occurred");
-            }
 
+                Log.error("App entry in the yaml input file has not a valid format or was missing");
+                return 1;
         }
     }
 

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/GetController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/GetController.java
@@ -3,7 +3,6 @@ package cloud.foundry.cli.services;
 import cloud.foundry.cli.crosscutting.beans.ApplicationBean;
 import cloud.foundry.cli.crosscutting.beans.ConfigBean;
 import cloud.foundry.cli.crosscutting.beans.ServiceBean;
-import cloud.foundry.cli.crosscutting.logging.Log;
 import cloud.foundry.cli.crosscutting.mapping.CfOperationsCreator;
 import cloud.foundry.cli.crosscutting.util.YamlCreator;
 import cloud.foundry.cli.operations.AllInformationOperations;
@@ -17,6 +16,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * This class realizes the functionality that is needed for the get commands. They provide various information about a
@@ -30,89 +30,79 @@ import java.util.Map;
                 GetController.GetSpaceDevelopersCommand.class,
                 GetController.GetApplicationsCommand.class,
                 GetController.GetAllInformation.class})
-public class GetController implements Runnable {
+public class GetController implements Callable<Integer> {
 
     @Override
-    public void run() {
-        // this code is executed if the user runs the get command without specifying any sub-command
+    public Integer call() throws Exception {
+        // by default, return all information
+        // this is a convenient shortcut
+        return (new GetController.GetAllInformation()).call();
     }
 
     @Command(name = "space-developers",
             description = "List all space developers in the target space.",
             mixinStandardHelpOptions = true
     )
-    static class GetSpaceDevelopersCommand implements Runnable {
+    static class GetSpaceDevelopersCommand implements Callable<Integer> {
         @Mixin
         LoginCommandOptions loginOptions;
 
         @Override
-        public void run() {
-            try {
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-                SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
-                Mono<List<String>> spaceDevelopers = spaceDevelopersOperations.getAll();
+        public Integer call() throws Exception {
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
+            Mono<List<String>> spaceDevelopers = spaceDevelopersOperations.getAll();
 
-                System.out.println(YamlCreator.createDefaultYamlProcessor().dump(spaceDevelopers.block()));
-            } catch (Exception e) {
-                Log.exception(e, "Unexpected error occurred");
-            }
+            System.out.println(YamlCreator.createDefaultYamlProcessor().dump(spaceDevelopers.block()));
+            return 0;
         }
     }
 
     @Command(name = "services", description = "List all services in the target space.")
-    static class GetServicesCommand implements Runnable {
+    static class GetServicesCommand implements Callable<Integer> {
         @Mixin
         LoginCommandOptions loginOptions;
 
         @Override
-        public void run() {
-            try {
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-                ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
-                Mono<Map<String,ServiceBean>> services = servicesOperations.getAll();
+        public Integer call() throws Exception {
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
+            Mono<Map<String,ServiceBean>> services = servicesOperations.getAll();
 
-                System.out.println(YamlCreator.createDefaultYamlProcessor().dump(services.block()));
-            } catch (Exception e) {
-                Log.exception(e, "Unexpected error occurred");
-            }
+            System.out.println(YamlCreator.createDefaultYamlProcessor().dump(services.block()));
+            return 0;
         }
     }
 
     @Command(name = "applications", description = "List all applications in the target space.")
-    static class GetApplicationsCommand implements Runnable {
+    static class GetApplicationsCommand implements Callable<Integer> {
         @Mixin
         LoginCommandOptions loginOptions;
 
         @Override
-        public void run() {
-            try {
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-                ApplicationOperations applicationOperations = new ApplicationOperations(cfOperations);
-                Mono<Map<String, ApplicationBean>> applications = applicationOperations.getAll();
+        public Integer call() throws Exception {
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            ApplicationOperations applicationOperations = new ApplicationOperations(cfOperations);
+            Mono<Map<String, ApplicationBean>> applications = applicationOperations.getAll();
 
-                System.out.println(YamlCreator.createDefaultYamlProcessor().dump(applications.block()));
-            } catch (Exception e) {
-                Log.exception(e, "Unexpected error occurred");
-            }
+            System.out.println(YamlCreator.createDefaultYamlProcessor().dump(applications.block()));
+            return 0;
         }
     }
 
     @Command(name = "all", description = "show all information in the target space")
-    static class GetAllInformation implements Runnable {
+    static class GetAllInformation implements Callable<Integer> {
         @Mixin
         LoginCommandOptions loginOptions;
 
         @Override
-        public void run() {
-            try {
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-                AllInformationOperations allInformationOperations = new AllInformationOperations(cfOperations);
-                ConfigBean allInformation = allInformationOperations.getAll();
+        public Integer call() throws Exception {
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            AllInformationOperations allInformationOperations = new AllInformationOperations(cfOperations);
+            ConfigBean allInformation = allInformationOperations.getAll();
 
-                System.out.println(YamlCreator.createDefaultYamlProcessor().dump(allInformation));
-            } catch (Exception e) {
-                Log.exception(e, "Unexpected error occurred");
-            }
+            System.out.println(YamlCreator.createDefaultYamlProcessor().dump(allInformation));
+            return 0;
         }
     }
 }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
@@ -3,11 +3,10 @@ package cloud.foundry.cli.services;
 import static picocli.CommandLine.Command;
 import static picocli.CommandLine.Mixin;
 
-import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import cloud.foundry.cli.crosscutting.beans.SpaceDevelopersBean;
-import cloud.foundry.cli.crosscutting.logging.Log;
 import cloud.foundry.cli.operations.SpaceDevelopersOperations;
 import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
 import org.yaml.snakeyaml.Yaml;
@@ -27,19 +26,20 @@ import cloud.foundry.cli.operations.ServicesOperations;
         UpdateController.RemoveSpaceDeveloperCommand.class,
         UpdateController.UpdateServiceCommand.class,
         UpdateController.UpdateApplicationCommand.class})
-public class UpdateController implements Runnable {
+public class UpdateController implements Callable<Integer> {
 
     private static final String FAILED_TO_READ_YAML_FILE = "Failed to read YAML file";
     private static final String UNEXPECTED_ERROR_OCCURRED = "Unexpected error occurred";
 
     @Override
-    public void run() {
+    public Integer call() throws Exception {
         // this code is executed if the user runs the create command without specifying
         // any sub-command
+        throw new UnsupportedOperationException("no default operation implemented in UpdateController");
     }
 
     @Command(name = "remove-space-developer", description = "Removes a space developer.")
-    static class RemoveSpaceDeveloperCommand implements Runnable {
+    static class RemoveSpaceDeveloperCommand implements Callable<Integer> {
         @Mixin
         LoginCommandOptions loginOptions;
 
@@ -47,29 +47,23 @@ public class UpdateController implements Runnable {
         CreateControllerCommandOptions commandOptions;
 
         @Override
-        public void run() {
-            String yamlFileContent;
-            try {
-                yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
-            } catch (IOException e) {
-                Log.exception(e, FAILED_TO_READ_YAML_FILE);
-                return;
-            }
+        public Integer call() throws Exception {
+            String yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
 
             Yaml yamlLoader = YamlCreator.createDefaultYamlProcessor();
+
             SpaceDevelopersBean spaceDevelopersBean = yamlLoader.loadAs(yamlFileContent, SpaceDevelopersBean.class);
-            try {
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-                SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
-                spaceDevelopersOperations.removeSpaceDeveloper(spaceDevelopersBean.getSpaceDevelopers());
-            } catch (Exception e) {
-                Log.exception(e, UNEXPECTED_ERROR_OCCURRED);
-            }
+
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
+            spaceDevelopersOperations.removeSpaceDeveloper(spaceDevelopersBean.getSpaceDevelopers());
+
+            return 0;
         }
     }
 
     @Command(name = "update-service", description = "Update a service instance")
-    static class UpdateServiceCommand implements Runnable {
+    static class UpdateServiceCommand implements Callable<Integer> {
 
         @Mixin
         LoginCommandOptions loginOptions;
@@ -78,40 +72,32 @@ public class UpdateController implements Runnable {
         CreateControllerCommandOptions commandOptions;
 
         @Override
-        public void run() {
-            String yamlFileContent;
-            try {
-                yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
-            } catch (IOException e) {
-                Log.exception(e, FAILED_TO_READ_YAML_FILE);
-                return;
-            }
+        public Integer call() throws Exception {
+            String yamlFileContent = FileUtils.readLocalFile(commandOptions.getYamlFilePath());
+
             Yaml yamlLoader = YamlCreator.createDefaultYamlProcessor();
 
-            try {
+            Map<String, Object> mapServiceBean = yamlLoader.loadAs(yamlFileContent, Map.class);
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
 
-                Map<String, Object> mapServiceBean = yamlLoader.loadAs(yamlFileContent, Map.class);
-                DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
+            for (String serviceInstanceName : mapServiceBean.keySet()) {
 
-                ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
-                for (String serviceInstanceName : mapServiceBean.keySet()) {
+                String serviceBeanYaml = yamlLoader.dump(mapServiceBean.get(serviceInstanceName));
+                ServiceBean serviceBean = yamlLoader.loadAs(serviceBeanYaml, ServiceBean.class);
+                // "currentName" is currently a placeholder until diff is implemented
+                servicesOperations.renameServiceInstance(serviceInstanceName, "currentName");
+                servicesOperations.updateServiceInstance(serviceInstanceName, serviceBean);
 
-                    String serviceBeanYaml = yamlLoader.dump(mapServiceBean.get(serviceInstanceName));
-                    ServiceBean serviceBean = yamlLoader.loadAs(serviceBeanYaml, ServiceBean.class);
-                    // "currentName" is currently a placeholder until diff is implemented
-                    servicesOperations.renameServiceInstance(serviceInstanceName, "currentName");
-                    servicesOperations.updateServiceInstance(serviceInstanceName, serviceBean);
-
-                }
-            } catch (Exception e) {
-                Log.exception(e, UNEXPECTED_ERROR_OCCURRED);
             }
+
+            return 0;
         }
     }
 
 
     @Command(name = "update-application", description = "Update ")
-    static class UpdateApplicationCommand implements Runnable {
+    static class UpdateApplicationCommand implements Callable<Integer> {
 
         @Mixin
         LoginCommandOptions loginOptions;
@@ -120,8 +106,8 @@ public class UpdateController implements Runnable {
         CreateControllerCommandOptions commandOptions;
 
         @Override
-        public void run() {
-
+        public Integer call() throws Exception {
+            throw new UnsupportedOperationException("update-application has not been implemented yet");
         }
     }
 }

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/operations/ServicesOperationsTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/operations/ServicesOperationsTest.java
@@ -43,10 +43,10 @@ public class ServicesOperationsTest {
                 .name("serviceName")
                 .plan("standardPlan")
                 .service("service")
-                .tags(List.of("tag"))
+                .tags(Arrays.asList("tag"))
                 .type(ServiceInstanceType.MANAGED)
                 .build();
-        List<ServiceInstanceSummary> withServices = List.of(summary);
+        List<ServiceInstanceSummary> withServices = Arrays.asList(summary);
 
         DefaultCloudFoundryOperations cfMock = mockGetAllMethod(withServices);
         ServicesOperations servicesOperations = new ServicesOperations(cfMock);

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/operations/SpaceDevelopersOperationsTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/operations/SpaceDevelopersOperationsTest.java
@@ -44,7 +44,7 @@ class SpaceDevelopersOperationsTest {
     @Test
     public void testGetSpaceDevelopers() {
         // given
-        List<String> withDevelopers = List.of("one", "two", "three");
+        List<String> withDevelopers = Arrays.asList("one", "two", "three");
         mockGetAllMethod(withDevelopers);
 
         // when


### PR DESCRIPTION
This PR:

- implements a centralized exception handling, where all exceptions can be handled properly
- ensures the tool returns with a non-zero code on errors
- allows called commands to exit with a custom return code, if needed
- removes duplicate error handling in the controllers

The most notable change developers will face is that now, instead of `Runnable`, `Callable<Integer>` is used for all subcommands, which allows for a) passing exceptions to said central exception handler and b) exiting with a custom error code if needed (there is one example for this in the code even).

P.S.: This PR fixes these annoying SLF4J messages. Turned out one just has to include some fallback handler. I chose `simple` over `nop` and all the other options, hoping that it'll work properly.