### PR TITLE
Get rid of annoying Javers log messages

### DIFF
--- a/cloud.foundry.cli/build.gradle
+++ b/cloud.foundry.cli/build.gradle
@@ -66,7 +66,10 @@ dependencies {
 
     // fix annoying error by including missing dependency
     // see http://www.slf4j.org/codes.html#StaticLoggerBinder
-    compile 'org.slf4j:slf4j-simple:1.7.+'
+    // we previously used org.slf4j:slf4j-simple, but we don't use it directly, only Javers needs it
+    // therefore, we can use the nop implementation, which doesn't generate any output, effectively hiding the Javers
+    // messages
+    compile 'org.slf4j:slf4j-nop:1.7.+'
 }
 
 test {


### PR DESCRIPTION
There are several ways how this could be implemented. This PR proposes the simplest form. By replacing the log implementation with a no-op one, the log messages go away, which is effectively what we want to have.

Alternatives involve configuring the default loglevel for all slf4j loggers, and configuring the Javers loggers directly. Those require more code, though.

It's possible to show them again by simply changing the implementation again. I documented this in the Gradle code.