### PR TITLE
Configure logging from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ java -jar cf-control.jar [COMMAND] [SUBCOMMAND] [PARAMS]
 
 ## Logging
 
-The application logs its activities using multiple loglevels. At the moment, the default level is `INFO`. Verbosity can be increased to *verbose* or even *debug* logging by setting the `VERBOSE` respectively `DEBUG` environment variables to any value.
+The application logs its activities using multiple loglevels. At the moment, the default level is `INFO`. Verbosity can be increased to *verbose* or even *debug* logging by setting the `VERBOSE` respectively `DEBUG` environment variables to any value, or by using the `--debug/-d` and `-v/--verbose` CLI options.
 
 The loglevel is always configured to the most verbose value the user specified. For instance, if both *verbose* and *debug* logging are enabled, the application will use the *debug* level.
+
+The application also supports a quiet mode, which can be enabled by setting the environment variable `QUIET` to any value or via the `-q/--quiet` CLI option.
 
 
 ## Available commands

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
@@ -28,6 +28,8 @@ public class Log {
 
     // by default, we only want to log messages of levels info and greater
     public static final Level DEFAULT_LEVEL = INFO_LEVEL;
+    // in quiet mode, we only want to log errors
+    public static final Level QUIET_LEVEL = ERROR_LEVEL;
 
     /**
      * The name of the CF-Control logger.
@@ -131,6 +133,13 @@ public class Log {
      */
     public static void setVerboseLogLevel() {
         setLogLevel(VERBOSE_LEVEL);
+    }
+
+    /**
+     * Configure logger to display verbose messages, too.
+     */
+    public static void setQuietLogLevel() {
+        setLogLevel(QUIET_LEVEL);
     }
 
     /**

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
@@ -17,8 +17,9 @@ public class Log {
     private static final Logger logger;
 
     // the name of the environment variable that needs to be set to turn on the debug messages
-    private static final String DEBUG_ENV_VAR_NAME = "DEBUG";
+    private static final String QUIET_ENV_VAR_NAME = "QUIET";
     private static final String VERBOSE_ENV_VAR_NAME = "VERBOSE";
+    private static final String DEBUG_ENV_VAR_NAME = "DEBUG";
 
     public static final Level ERROR_LEVEL = Level.SEVERE;
     public static final Level WARNING_LEVEL = Level.WARNING;
@@ -45,6 +46,12 @@ public class Log {
 
         // set default log level
         setDefaultLogLevel();
+
+        // by default, we don't want to log verbose messages
+        // however, the user can opt-in to them by setting the environment variable $VERBOSE
+        if (System.getenv(QUIET_ENV_VAR_NAME) != null) {
+            setQuietLogLevel();
+        }
 
         // by default, we don't want to log verbose messages
         // however, the user can opt-in to them by setting the environment variable $VERBOSE

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -12,6 +12,7 @@ import org.yaml.snakeyaml.constructor.ConstructorException;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine;
+import picocli.CommandLine.Option;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -33,13 +34,13 @@ import java.util.concurrent.Callable;
 public class BaseController implements Callable<Integer> {
 
     private static class LoggingOptions {
-        @CommandLine.Option(names = {"-q", "--quiet"}, description = "Reduce log verbosity and print errors only.")
+        @Option(names = {"-q", "--quiet"}, description = "Reduce log verbosity and print errors only.")
         private boolean quiet;
 
-        @CommandLine.Option(names = {"-v", "--verbose"}, description = "Enable verbose logging.")
+        @Option(names = {"-v", "--verbose"}, description = "Enable verbose logging.")
         private boolean verbose;
 
-        @CommandLine.Option(names = {"-d", "--debug"}, description = "Enable debug logging.")
+        @Option(names = {"-d", "--debug"}, description = "Enable debug logging.")
         private boolean debug;
 
         public boolean isVerbose() {

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -31,26 +31,31 @@ import java.util.concurrent.Callable;
         UpdateController.class})
 public class BaseController implements Callable<Integer> {
 
-    @CommandLine.Option(names = {"-q", "--quiet"}, description = "Reduce log verbosity and print errors only.")
-    private boolean quiet;
+    private static class LoggingOptions {
+        @CommandLine.Option(names = {"-q", "--quiet"}, description = "Reduce log verbosity and print errors only.")
+        private boolean quiet;
 
-    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Enable verbose logging.")
-    private boolean verbose;
+        @CommandLine.Option(names = {"-v", "--verbose"}, description = "Enable verbose logging.")
+        private boolean verbose;
 
-    @CommandLine.Option(names = {"-d", "--debug"}, description = "Enable debug logging.")
-    private boolean debug;
+        @CommandLine.Option(names = {"-d", "--debug"}, description = "Enable debug logging.")
+        private boolean debug;
 
-    public boolean isVerbose() {
-        return verbose;
+        public boolean isVerbose() {
+            return verbose;
+        }
+
+        public boolean isDebug() {
+            return debug;
+        }
+
+        public boolean isQuiet() {
+            return quiet;
+        }
     }
 
-    public boolean isDebug() {
-        return debug;
-    }
-
-    public boolean isQuiet() {
-        return quiet;
-    }
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    LoggingOptions loggingOptions;
 
     @Override
     public Integer call() {
@@ -130,17 +135,16 @@ public class BaseController implements Callable<Integer> {
         // now, we can access the logging options in the base controller
         // note: we always enable the most verbose level the user specifies
         // for that reason we can't use an if-else, but must use a chain of plain if clauses
-        // TODO: check if mutually exclusive argument group provides a better UX
-        if (controller.isQuiet()) {
+        if (controller.loggingOptions.isQuiet()) {
             // wouldn't make sense to log that we enabled the quiet mode, right?
             // the whole idea is to reduce the amount of log messages
             Log.setQuietLogLevel();
         }
-        if (controller.isVerbose()) {
+        if (controller.loggingOptions.isVerbose()) {
             Log.setVerboseLogLevel();
             Log.verbose("enabling verbose logging");
         }
-        if (controller.isDebug()) {
+        if (controller.loggingOptions.isDebug()) {
             Log.setDebugLogLevel();
             Log.debug("enabling debug logging");
         }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -9,6 +9,7 @@ import cloud.foundry.cli.crosscutting.exceptions.ApplyException;
 import cloud.foundry.cli.crosscutting.logging.Log;
 import cloud.foundry.cli.crosscutting.mapping.RefResolver;
 import org.yaml.snakeyaml.constructor.ConstructorException;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine;
 
@@ -54,7 +55,7 @@ public class BaseController implements Callable<Integer> {
         }
     }
 
-    @CommandLine.ArgGroup(exclusive = true, multiplicity = "0..1")
+    @ArgGroup(exclusive = true, multiplicity = "0..1")
     LoggingOptions loggingOptions;
 
     @Override

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -31,6 +31,27 @@ import java.util.concurrent.Callable;
         UpdateController.class})
 public class BaseController implements Callable<Integer> {
 
+    @CommandLine.Option(names = {"-q", "--quiet"}, description = "Reduce log verbosity and print errors only.")
+    private boolean quiet;
+
+    @CommandLine.Option(names = {"-v", "--verbose"}, description = "Enable verbose logging.")
+    private boolean verbose;
+
+    @CommandLine.Option(names = {"-d", "--debug"}, description = "Enable debug logging.")
+    private boolean debug;
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public boolean isDebug() {
+        return debug;
+    }
+
+    public boolean isQuiet() {
+        return quiet;
+    }
+
     @Override
     public Integer call() {
         // this code is executed if the user just runs the app
@@ -39,7 +60,15 @@ public class BaseController implements Callable<Integer> {
     }
 
     public static void main(String[] args) {
-        CommandLine cli = new CommandLine(new BaseController());
+        // now, this is a little annoying, but it seems picocli doesn't provide any other option
+        // in order to be able to handle the global logging options, we need to access the values in the base
+        // controller
+        // unfortunately, these are populated only once we call parseArgs or execute
+        // therefore, we have to parse the arguments twice: once with a parseArgs() call to be able to handle the
+        // logging options, then again in the execute() call which runs the subcommands etc.
+        BaseController controller = new BaseController();
+
+        CommandLine cli = new CommandLine(controller);
 
         // picocli has a nice hidden feature: one can register a special exception handler and thus deal with
         // exceptions occurring during the execution of a Callable, Runnable etc.
@@ -93,10 +122,32 @@ public class BaseController implements Callable<Integer> {
             // no need for returning different exit codes for different exceptions, but that's also possible in the
             // future
             return 1;
-        }
-        );
+        });
 
+        // parse args now to be able to configure logging before we continue running the rest of the CLI
+        cli.parseArgs(args);
+
+        // now, we can access the logging options in the base controller
+        // note: we always enable the most verbose level the user specifies
+        // for that reason we can't use an if-else, but must use a chain of plain if clauses
+        // TODO: check if mutually exclusive argument group provides a better UX
+        if (controller.isQuiet()) {
+            // wouldn't make sense to log that we enabled the quiet mode, right?
+            // the whole idea is to reduce the amount of log messages
+            Log.setQuietLogLevel();
+        }
+        if (controller.isVerbose()) {
+            Log.setVerboseLogLevel();
+            Log.verbose("enabling verbose logging");
+        }
+        if (controller.isDebug()) {
+            Log.setDebugLogLevel();
+            Log.debug("enabling debug logging");
+        }
+
+        // okay, logging is configured, now let's run the rest of the CLI
         int exitCode = cli.execute(args);
+
         System.exit(exitCode);
     }
 

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -134,7 +134,7 @@ public class BaseController implements Callable<Integer> {
         // a nice catch of this approach: we can properly handle all sorts of argument parsing errors nicely
         try {
             cli.parseArgs(args);
-        } catch (CommandLine.PicocliException e) {
+        } catch (Exception e) {
             // TODO: consider printing this directly to stderr
             // (we don't necessarily need to use the logger while parsing the args)
             Log.error(e.getMessage());

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -130,7 +130,15 @@ public class BaseController implements Callable<Integer> {
         });
 
         // parse args now to be able to configure logging before we continue running the rest of the CLI
-        cli.parseArgs(args);
+        // a nice catch of this approach: we can properly handle all sorts of argument parsing errors nicely
+        try {
+            cli.parseArgs(args);
+        } catch (CommandLine.PicocliException e) {
+            // TODO: consider printing this directly to stderr
+            // (we don't necessarily need to use the logger while parsing the args)
+            Log.error(e.getMessage());
+            System.exit(1);
+        }
 
         // now, we can access the logging options in the base controller
         // note: we always enable the most verbose level the user specifies

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogTest.java
@@ -181,4 +181,29 @@ public class LogTest {
         assert lastRecord.getThrown() == exception;
     }
 
+    @Test
+    public void testQuietMode() {
+        // test whether quiet mode works as intended
+        Log.setQuietLogLevel();
+
+        // none of these messages should reach our handler
+        Log.debug(uniqueTestString);
+        Log.verbose(uniqueTestString);
+        Log.info(uniqueTestString);
+        Log.warning(uniqueTestString);
+
+        // debug messages should not be visible by default
+        assertNoMessagesRecorded();
+
+        // errors should be recorded even in quiet mode
+        Log.error(uniqueTestString);
+
+        LogRecord lastRecord = popLastRecord();
+        assert lastRecord.getLevel() == Log.ERROR_LEVEL;
+        assert lastRecord.getMessage().contains(uniqueTestString);
+
+        // now all messages should be handled
+        assertNoMessagesRecorded();
+    }
+
 }

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogTest.java
@@ -109,6 +109,9 @@ public class LogTest {
         LogRecord lastRecord = popLastRecord();
         assert lastRecord.getLevel() == Log.ERROR_LEVEL;
         assert lastRecord.getMessage().contains(uniqueTestString);
+
+        // now all messages should be handled
+        assertNoMessagesRecorded();
     }
 
     @Test
@@ -118,6 +121,9 @@ public class LogTest {
         LogRecord lastRecord = popLastRecord();
         assert lastRecord.getLevel() == Log.WARNING_LEVEL;
         assert lastRecord.getMessage().contains(uniqueTestString);
+
+        // now all messages should be handled
+        assertNoMessagesRecorded();
     }
 
     @Test
@@ -127,6 +133,9 @@ public class LogTest {
         LogRecord lastRecord = popLastRecord();
         assert lastRecord.getLevel() == Log.INFO_LEVEL;
         assert lastRecord.getMessage().contains(uniqueTestString);
+
+        // now all messages should be handled
+        assertNoMessagesRecorded();
     }
 
     @Test
@@ -144,6 +153,9 @@ public class LogTest {
         LogRecord lastRecord = popLastRecord();
         assert lastRecord.getLevel() == Log.VERBOSE_LEVEL;
         assert lastRecord.getMessage().contains(uniqueTestString);
+
+        // now all messages should be handled
+        assertNoMessagesRecorded();
     }
 
     @Test
@@ -161,6 +173,9 @@ public class LogTest {
         LogRecord lastRecord = popLastRecord();
         assert lastRecord.getLevel() == Log.DEBUG_LEVEL;
         assert lastRecord.getMessage().contains(uniqueTestString);
+
+        // now all messages should be handled
+        assertNoMessagesRecorded();
     }
 
     @Test
@@ -179,6 +194,9 @@ public class LogTest {
         assert lastRecord.getLevel() == Log.ERROR_LEVEL;
         assert lastRecord.getMessage().contains(uniqueTestString);
         assert lastRecord.getThrown() == exception;
+
+        // now all messages should be handled
+        assertNoMessagesRecorded();
     }
 
     @Test


### PR DESCRIPTION
Fixes #64.

This PR introduces the `-v`, `-d` and `-q` CLI options which allow for configuring the logging verbosity. They work similar to the environment variables documented in the README.

- `-q` sets the loglevel to "error", effectively hiding all log messages unless something goes wrong
- `-v` sets the loglevel to "verbose", increasing the verbosity in comparison to the default mode, but hiding information only interesting to developers
- `-d` sets the loglevel to "debug", the most verbose loglevel

If none of these options is supplied, the normal "info" loglevel is used.

P.S.: Oh, and it adds the `$QUIET` env var that is documented but unfortunately hasn't been available yet.