### PR TITLE
Fix logging verbosity configuration bug

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
@@ -115,8 +115,15 @@ public class Log {
      * @param level messages of this or any higher level will be shown by the logger
      */
     public static void setLogLevel(Level level) {
+        // configure own logger
         logger.setLevel(level);
         Arrays.stream(logger.getHandlers()).forEach(h -> h.setLevel(level));
+
+        // our "nearest parent" _should_ be the root logger
+        // we need to configure its handlers to output the messages < INFO as well
+        // note: do not configure its log level -- this will cause all other loggers' level too, and generate a lot of
+        // noise on the CLI
+        Arrays.stream(logger.getParent().getHandlers()).forEach(h -> h.setLevel(level));
     }
 
     /**


### PR DESCRIPTION
While our unit tests showed that the log configuration worked as intended, the more verbose loglevel messages were not shown on the commandline. We need to configure the root log handler to output verbose messages as well.

It's very important not to configure the root logger's level, as this has an influence on all other loggers running in all libraries etc., causing a lot of log noise on the CLI.

Thanks @TobiCode for discovering this bug.