### PR TITLE
Improve service deletion

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
@@ -91,7 +91,7 @@ public class UpdateController implements Callable<Integer> {
             Map<String, ServiceBean> services = readServicesFromYamlFile();
 
             // in case the --force flag is not specified, we shall prompt the user to prevent the removal of services
-            // as that might remove valuable data a swell
+            // as that might remove valuable data as well
             if (force == null) {
                 if (System.console() == null) {
                     Log.error("--force/-f not supplied and not running in terminal, aborting");

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
@@ -119,7 +119,13 @@ public class UpdateController implements Callable<Integer> {
                 }
             }
 
-            doRemoveServiceInstance(services);
+            // in case the service doesn't exist on the server, it'll throw that exception
+            // we can recognize that and log it nicely
+            try {
+                doRemoveServiceInstance(services);
+            } catch (IllegalArgumentException e) {
+                Log.error(e);
+            }
             
             return 0;
         }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
@@ -81,11 +81,6 @@ public class UpdateController implements Callable<Integer> {
         @Option(names = { "-f", "--force" }, required = false, description = "Force deletion without confirmation.")
         Boolean force;
 
-        private Map<String, ServiceBean> readServicesFromYamlFile() throws IOException {
-            SpecBean specBean = YamlMapper.loadBean(yamlCommandOptions.getYamlFilePath(), SpecBean.class);
-            return specBean.getServices();
-        }
-
         @Override
         public Integer call() throws Exception {
             Map<String, ServiceBean> services = readServicesFromYamlFile();
@@ -124,6 +119,11 @@ public class UpdateController implements Callable<Integer> {
             doRemoveServiceInstance(services);
             
             return 0;
+        }
+
+        private Map<String, ServiceBean> readServicesFromYamlFile() throws IOException {
+            SpecBean specBean = YamlMapper.loadBean(yamlCommandOptions.getYamlFilePath(), SpecBean.class);
+            return specBean.getServices();
         }
 
         /**

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
@@ -81,14 +81,14 @@ public class UpdateController implements Callable<Integer> {
         @Option(names = { "-f", "--force" }, required = false, description = "Force deletion without confirmation.")
         Boolean force;
 
-        private Map<String, ServiceBean> readServicesFromYAMLFile() throws IOException {
+        private Map<String, ServiceBean> readServicesFromYamlFile() throws IOException {
             SpecBean specBean = YamlMapper.loadBean(yamlCommandOptions.getYamlFilePath(), SpecBean.class);
             return specBean.getServices();
         }
 
         @Override
         public Integer call() throws Exception {
-            Map<String, ServiceBean> services = readServicesFromYAMLFile();
+            Map<String, ServiceBean> services = readServicesFromYamlFile();
 
             // in case the --force flag is not specified, we shall prompt the user to prevent the removal of services
             // as that might remove valuable data a swell

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/UpdateController.java
@@ -90,9 +90,9 @@ public class UpdateController implements Callable<Integer> {
         public Integer call() throws Exception {
             Map<String, ServiceBean> services = readServicesFromYAMLFile();
 
-            if (force != null) {
-                doRemoveServiceInstance(services);
-            } else {
+            // in case the --force flag is not specified, we shall prompt the user to prevent the removal of services
+            // as that might remove valuable data a swell
+            if (force == null) {
                 if (System.console() == null) {
                     Log.error("--force/-f not supplied and not running in terminal, aborting");
                     return 2;
@@ -113,13 +113,13 @@ public class UpdateController implements Callable<Integer> {
                 // turn into lower case, we would accept an upper case response, too
                 input = input.toLowerCase();
 
-                if (input.equals("y") || input.equals("yes")) {
-                    doRemoveServiceInstance(services);
-                } else {
+                if (!(input.equals("y") || input.equals("yes"))) {
                     System.out.println("Cancelled by user");
                     return 1;
                 }
             }
+
+            doRemoveServiceInstance(services);
             
             return 0;
         }


### PR DESCRIPTION
Fixes #83. A bit of refactoring was required, did a little more to make the program flow a little more "flat". Also found an annoyance (an exception used to be thrown whenever you try to remove a non-existing service), that's also fixed.