### PR TITLE
Add --log-file CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The loglevel is always configured to the most verbose value the user specified. 
 
 The application also supports a quiet mode, which can be enabled by setting the environment variable `QUIET` to any value or via the `-q/--quiet` CLI option.
 
+You can have the tool create a machine-readable log file by specifying the `--log-file my.log` parameter. The output format is XML and should be straightforward to read and parse.
+
 
 ## Available commands
 

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -153,7 +153,7 @@ public class BaseController implements Callable<Integer> {
                 try {
                     Log.addHandler(new FileHandler(controller.logFile));
                 } catch (IOException e) {
-                    log.error("Could not open log file", controller.logFile);
+                    Log.error("Could not open log file", controller.logFile);
                     System.exit(1);
                 }
             }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -158,7 +158,7 @@ public class BaseController implements Callable<Integer> {
                 try {
                     fileHandler = new FileHandler(controller.logFile);
                 } catch (IOException e) {
-                    Log.error("Could not open log file", controller.logFile);
+                    log.error("Could not open log file", controller.logFile);
                     System.exit(1);
                 }
             }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -16,6 +16,7 @@ import picocli.CommandLine.Option;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
+import java.util.logging.FileHandler;
 
 /**
  * This class works as the entry point for the command line application.
@@ -58,6 +59,9 @@ public class BaseController implements Callable<Integer> {
 
     @ArgGroup(exclusive = true, multiplicity = "0..1")
     LoggingOptions loggingOptions;
+
+    @Option(names = {"--log-file"}, description = "Write logs to file.")
+    private String logFile;
 
     @Override
     public Integer call() {
@@ -144,6 +148,16 @@ public class BaseController implements Callable<Integer> {
 
         // seems like picocli doesn't populate the logging options unless either of them is passed
         if (controller.loggingOptions != null) {
+            // in case a log file path has been passed, all we have to do is add a file handler for this path
+            if (controller.logFile != null) {
+                try {
+                    Log.addHandler(new FileHandler(controller.logFile));
+                } catch (IOException e) {
+                    log.error("Could not open log file", controller.logFile);
+                    System.exit(1);
+                }
+            }
+
             // now, we can access the logging options in the base controller
             // note: we always enable the most verbose level the user specifies
             // for that reason we can't use an if-else, but must use a chain of plain if clauses

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -146,12 +146,15 @@ public class BaseController implements Callable<Integer> {
             System.exit(1);
         }
 
+        // will be registered as a handler in the log in case the user enables it
+        FileHandler fileHandler = null;
+
         // seems like picocli doesn't populate the logging options unless either of them is passed
         if (controller.loggingOptions != null) {
             // in case a log file path has been passed, all we have to do is add a file handler for this path
             if (controller.logFile != null) {
                 try {
-                    Log.addHandler(new FileHandler(controller.logFile));
+                    fileHandler = new FileHandler(controller.logFile);
                 } catch (IOException e) {
                     Log.error("Could not open log file", controller.logFile);
                     System.exit(1);
@@ -176,8 +179,19 @@ public class BaseController implements Callable<Integer> {
             }
         }
 
+        // register in the log if available
+        if (fileHandler != null) {
+            Log.addHandler(fileHandler);
+        }
+
         // okay, logging is configured, now let's run the rest of the CLI
         int exitCode = cli.execute(args);
+
+        // make sure to close the file handler to make sure it writes valid XML including all closing tags
+        if (fileHandler != null) {
+            Log.removeHandler(fileHandler);
+            fileHandler.close();
+        }
 
         System.exit(exitCode);
     }

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
@@ -13,6 +13,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.Paths;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.List;
@@ -83,7 +84,7 @@ public class LogFileTest {
         final List<String> args = new ArrayList<>();
 
         // we expect the application to write to this log file
-        final File logFile = new File(tempDir + "/test.log");
+        final File logFile = Paths.get(tempDir.toString(), "test.log").toFile();
 
         args.add("--log-file");
         args.add(logFile.getAbsolutePath());

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
@@ -1,11 +1,12 @@
 package cloud.foundry.cli.crosscutting.logging;
 
 import cloud.foundry.cli.services.BaseController;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
@@ -1,0 +1,142 @@
+package cloud.foundry.cli.crosscutting.logging;
+
+import cloud.foundry.cli.services.BaseController;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Integration test for --log-file feature.
+ */
+public class LogFileTest {
+    /**
+     * Thrown by custom security manager whenever System.exit(...) is called.
+     */
+    protected static class SystemExitException extends SecurityException {
+        private final int exitCode;
+
+        public SystemExitException(int exitCode) {
+            this.exitCode = exitCode;
+        }
+
+        public int getExitCode() {
+            return exitCode;
+        }
+    }
+
+    /**
+     * Custom security manager which prevents the JVM from exiting.
+     * Instead, it raises a {@link SystemExitException} when there's a call to System.exit(...).
+     */
+    private static class PreventExitSecurityManager extends SecurityManager {
+        // these checkPermission overrides are needed for some reason...
+        @Override
+        public void checkPermission(Permission perm) {}
+
+        @Override
+        public void checkPermission(Permission perm, Object context) {}
+
+        @Override
+        public void checkExit(int status) {
+            super.checkExit(status);
+            throw new SystemExitException(status);
+        }
+    }
+
+    @BeforeAll
+    private static void installCustomSecurityManager() {
+        System.setSecurityManager(new PreventExitSecurityManager());
+    }
+
+    @AfterAll
+    private static void restoreOriginalSecurityManager() {
+        System.setSecurityManager(null);
+    }
+
+    // we use this directory to store the log files in
+    // since it's an instance member, it should be cleaned up and recreated between the tests
+    @TempDir
+    File tempDir;
+
+    private void runBaseControllerWithArgs(List<String> args) {
+        // to simulate a main() run, we need a regular String array
+        String[] argsArray = new String[args.size()];
+        args.toArray(argsArray);
+
+        BaseController.main(argsArray);
+    }
+
+    @Test
+    public void testBaseController() throws ParserConfigurationException, IOException, SAXException {
+        final List<String> args = new ArrayList<>();
+
+        // we expect the application to write to this log file
+        final File logFile = new File(tempDir + "/test.log");
+
+        args.add("--log-file");
+        args.add(logFile.getAbsolutePath());
+
+        // let's be as verbose as possible
+        args.add("-d");
+
+        // first random command; doesn't really matter, it won't work anyway
+        args.add("get");
+        args.add("space-developers");
+
+        // need to provide *all* required CLI options, otherwise the tool will error out even _before_ the log file
+        // parameter could be evaluated
+        // FIXME: can be removed once #92 has been merged
+        args.add("-a");
+        args.add("test");
+
+        args.add("-o");
+        args.add("test");
+
+        args.add("-s");
+        args.add("test");
+
+        int exitCode = -1;
+
+        try {
+            runBaseControllerWithArgs(args);
+        } catch (SystemExitException e) {
+            exitCode = e.getExitCode();
+        }
+
+        assert exitCode == 1;
+
+        // let's see if the application wrote something into the log file
+        DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+        // Java XML log files contain references to some "logger.dtd" file, which we have to ignore
+        documentBuilder.setEntityResolver((s, s1) -> {
+            if (s1.endsWith("logger.dtd")) {
+                return new InputSource(new StringReader(""));
+            }
+            return null;
+        });
+
+        // possibly due to System.exit calls, the log file ends without its closing </log> tag
+        // since the issue is known, we can ignore it for now
+        try {
+            documentBuilder.parse(logFile);
+        } catch (SAXParseException e) {
+            // rethrow unless it's the one we expect
+            if (!e.getMessage().contains("XML document structures must start and end within the same entity"))
+                throw e;
+        }
+    }
+
+}

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/logging/LogFileTest.java
@@ -130,13 +130,7 @@ public class LogFileTest {
 
         // possibly due to System.exit calls, the log file ends without its closing </log> tag
         // since the issue is known, we can ignore it for now
-        try {
-            documentBuilder.parse(logFile);
-        } catch (SAXParseException e) {
-            // rethrow unless it's the one we expect
-            if (!e.getMessage().contains("XML document structures must start and end within the same entity"))
-                throw e;
-        }
+        documentBuilder.parse(logFile);
     }
 
 }


### PR DESCRIPTION
Closes #86.

This PR introduces a `--log-file` flag. All logs created by this application are stored in this file.

As of yet, the logs are stored in XML format. That's Java's default. It'd satisfy the acceptance criteria, but is most useful for machine processing. The sprint backlog item doesn't define whether this is what was intended. Given the purpose of the tool (running on a CI system to apply changes to infrastructure), it might actually be an advantage to have XML style logs.

Here's an example message:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE log SYSTEM "logger.dtd">
<log>
<record>
  <date>2020-06-23T23:47:08.956185Z</date>
  <millis>1592956028956</millis>
  <nanos>185000</nanos>
  <sequence>0</sequence>
  <logger>cfctl</logger>
  <level>FINER</level>
  <class>cloud.foundry.cli.crosscutting.logging.Log</class>
  <method>log</method>
  <thread>1</thread>
  <message>enabling debug logging</message>
</record>
[...]
```

It is possible to change the output format if needed. The XML contains a lot of misleading information (e.g., `class` and `method` are clearly wrong) anyway.