### PR TITLE
Enforce default console log format

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/logging/Log.java
@@ -42,6 +42,13 @@ public class Log {
         System.setProperty("user.language", "en");
         Locale.setDefault(new Locale("en", "EN"));
 
+        // change global stdout log format
+        // desired output format: <date> <time> <logger name> [<loglevel>]: <message>
+        System.setProperty(
+                "java.util.logging.SimpleFormatter.format",
+                "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %3$s [%4$-5s] %5$s%6$s%n"
+        );
+
         logger = java.util.logging.Logger.getLogger(LOGGER_NAME);
 
         // set default log level


### PR DESCRIPTION
Goals:
  - single line
  - show logger name instead of class/method where it was called (that doesn't work with our logger)
  - show per message: date, time, logger name, log level, message

Example output:

```
2020-06-24 02:02:32 cfctl [FINER] enabling debug logging
2020-06-24 02:02:32 cfctl [FINER] Create the cfOperations object with your login command options...
2020-06-24 02:02:33 cfctl [INFO ] Fetching information of space developers...
```

Note: it shows the Java log level names, not the (more standard) ones we use internally.

CC #95, #86.