### PR TITLE
Don't append login options for base controller

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
@@ -44,8 +44,9 @@ public class CfArgumentsCreator {
      */
     public static String[] determineCommandLine(CommandLine cli, String[] args, CommandLine.ParseResult subcommand) {
         // exclude commands which don't use the cloud.foundry.cli.services.LoginCommandOptions mixin
+        // if the subcommand is null, we're in the base controller (or its help options)
         // TODO: find out whether it's possible to recognize the LoginCommandOptions mixin with reflections only
-        if (subcommand != null && subcommand.commandSpec().userObject() instanceof DumpController) {
+        if (subcommand == null || subcommand.commandSpec().userObject() instanceof DumpController) {
             return args;
         }
 

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreatorTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreatorTest.java
@@ -22,7 +22,7 @@ public class CfArgumentsCreatorTest {
         String[] result = CfArgumentsCreator.determineCommandLine(
                 cli,
                 new String[]{"diff", "services", "-y", "somePath"},
-                null
+                CommandLine.ParseResult.builder(CommandLine.Model.CommandSpec.create()).build()
         );
 
         // then
@@ -40,7 +40,7 @@ public class CfArgumentsCreatorTest {
         String[] result = CfArgumentsCreator.determineCommandLine(
                 cli,
                 new String[]{"diff", "services", "-s", "development", "-y", "somePath"},
-                null
+                CommandLine.ParseResult.builder(CommandLine.Model.CommandSpec.create()).build()
         );
 
         // then


### PR DESCRIPTION
This bug was discovered when calling the JAR without any arguments (or without providing a subcommand name). The options would be appended nevertheless, yielding some annoying warnings the user cannot possibly interpret.