### PR TITLE
Bugfix/apply space arguments creator

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
@@ -86,8 +86,9 @@ public class CfArgumentsCreator {
         }
 
         log.verbose("User has not passed values for arguments ", missingOptions, ", using default values");
-
-        if (asList(args).contains("get")) {
+        // In apply space we don't have a yaml file. Should behave in the same way as the get command
+        //TODO: Remove this if, after cretaing apply all and removing apply subcommands
+        if (asList(args).contains("get") || asList(args).contains("space")) {
             // get missing values from config-properties File and extend to get command
             return extendForGetCommand(missingOptions, new LinkedList<>(asList(args)));
         } else {

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
@@ -87,7 +87,8 @@ public class CfArgumentsCreator {
 
         log.verbose("User has not passed values for arguments ", missingOptions, ", using default values");
         // In apply space we don't have a yaml file. Should behave in the same way as the get command
-        //TODO: Remove this if, after cretaing apply all and removing apply subcommands
+        //TODO: Remove the contains space condition after creating apply all US is done
+        //and apply subcommands are removed
         if (asList(args).contains("get") || asList(args).contains("space")) {
             // get missing values from config-properties File and extend to get command
             return extendForGetCommand(missingOptions, new LinkedList<>(asList(args)));


### PR DESCRIPTION
Quick fix. Introduced with new Arguments handling. My US apply space would be not runnable without this fix.
Introduced special handling in the ArgumentsCreator for my space command. 
The special handling can be removed again if the apply all US is implemented and the apply space subcommand is removed.