### PR TITLE
Better log messages

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfArgumentsCreator.java
@@ -85,7 +85,8 @@ public class CfArgumentsCreator {
             }
         }
 
-        log.verbose("User has not passed values for arguments ", missingOptions, ", using default values");
+        log.verbose("User has not passed values for arguments", missingOptions + ", using default values");
+
         // In apply space we don't have a yaml file. Should behave in the same way as the get command
         //TODO: Remove the contains space condition after creating apply all US is done
         //and apply subcommands are removed
@@ -96,6 +97,10 @@ public class CfArgumentsCreator {
             // get missing values from the given YAML File and extend to diff/apply command
             return extendForDiffAndApplyCommand(missingOptions, new LinkedList<>(asList(args)));
         }
+    }
+
+    private static void logExtendedOption(String key, String value) {
+        log.info("Extended commandline arguments with option", key, "and value", value);
     }
 
     /**
@@ -114,12 +119,14 @@ public class CfArgumentsCreator {
             Properties prop = new Properties();
             prop.load(input);
 
-            missingOptions.forEach(key -> {
-                args.add(key);
-                args.add(prop.getProperty(key));
 
-                log.info("Extended CommandLine Argument with the Option: " + key +
-                    " and value " + "'" + prop.getProperty(key) + "'");
+            missingOptions.forEach(key -> {
+                String value = prop.getProperty(key);
+
+                args.add(key);
+                args.add(value);
+
+                logExtendedOption(key, value);
             });
         } catch (IOException ex) {
             log.error(ex.getMessage());
@@ -138,7 +145,6 @@ public class CfArgumentsCreator {
      * @return Commandline arguments
      */
     private static String[] extendForDiffAndApplyCommand(List<String> missingOptions, LinkedList<String> args) {
-
         String yamlPath = args.get(args.indexOf("-y") + 1);
         ConfigBean configBean =  new ConfigBean();
 
@@ -152,7 +158,9 @@ public class CfArgumentsCreator {
         TargetBean targetBean = configBean.getTarget();
         missingOptions.forEach(key -> {
             args.add(key);
+
             String value = "";
+
             switch (key) {
             case "-a":
                 value = targetBean.getEndpoint();
@@ -168,8 +176,8 @@ public class CfArgumentsCreator {
             }
 
             args.add(value);
-            log.info("Extended CommandLine Argument with the Option: " + key +
-                " and value " + "'" + value + "'");
+
+            logExtendedOption(key, value);
         });
 
         return args.toArray(new String[0]);

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfOperationsCreator.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/CfOperationsCreator.java
@@ -30,7 +30,7 @@ public class CfOperationsCreator {
      * @throws MissingCredentialsException if either the username or the password cannot be determined
      */
     public static DefaultCloudFoundryOperations createCfOperations(LoginCommandOptions commandOptions) {
-        log.debug("Building CF operations object with your login command options...");
+        log.debug("Setting up CF operations object with your login command options");
 
         DefaultConnectionContext connectionContext = createConnectionContext(commandOptions);
         PasswordGrantTokenProvider tokenProvider = createTokenProvider(commandOptions);

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/RefResolver.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/RefResolver.java
@@ -48,7 +48,7 @@ public class RefResolver implements YamlTreeVisitor {
      * @throws RefResolvingException if an error during the ref-resolution process occurs
      */
     public static Object resolveRefs(Object yamlTreeRoot, String rootFilePath) {
-        log.debug("Resolve", RefResolver.REF_KEY + "-occurrences");
+        log.debug("Resolving occurrences of", RefResolver.REF_KEY);
 
         RefResolver refResolvingYamlTreeVisitor = new RefResolver(yamlTreeRoot, rootFilePath);
         Object resolvedYamlTreeRoot = refResolvingYamlTreeVisitor.doResolveRefs();
@@ -77,9 +77,9 @@ public class RefResolver implements YamlTreeVisitor {
 
     private void visitRefMapping(Map<Object, Object> refMappingNode) {
         Object refValueNode = refMappingNode.get(REF_KEY);
-        log.debug("Encountered", RefResolver.REF_KEY + "-occurrence with value", String.valueOf(refValueNode));
+        log.debug("Encountered", RefResolver.REF_KEY, "occurrence with value", String.valueOf(refValueNode));
         if (!(refValueNode instanceof String)) {
-            throw new RefResolvingException("Encountered a '" + REF_KEY + "'-occurrence where its value is not of" +
+            throw new RefResolvingException("Encountered a '" + REF_KEY + "' occurrence where its value is not of" +
                     " type string");
         }
         String refValue = (String) refValueNode;
@@ -97,7 +97,7 @@ public class RefResolver implements YamlTreeVisitor {
             throw new RefResolvingException(message, e);
         }
 
-        log.debug("Reading content of", filePath);
+        log.debug("Reading YAML file", filePath);
         Object referredYamlTree;
         try {
             referredYamlTree = YamlMapper.loadYamlTreeFromFilePath(absoluteFilePath);

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/ApplyLogic.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/ApplyLogic.java
@@ -9,9 +9,9 @@ import cloud.foundry.cli.crosscutting.mapping.beans.ConfigBean;
 import cloud.foundry.cli.crosscutting.mapping.beans.ServiceBean;
 import cloud.foundry.cli.crosscutting.mapping.beans.SpecBean;
 import cloud.foundry.cli.crosscutting.exceptions.ApplyException;
-import cloud.foundry.cli.logic.apply.ApplicationRequestsPlaner;
-import cloud.foundry.cli.logic.apply.ServiceRequestsPlaner;
-import cloud.foundry.cli.logic.apply.SpaceDevelopersRequestsPlaner;
+import cloud.foundry.cli.logic.apply.ApplicationRequestsPlanner;
+import cloud.foundry.cli.logic.apply.ServiceRequestsPlanner;
+import cloud.foundry.cli.logic.apply.SpaceDevelopersRequestsPlanner;
 import cloud.foundry.cli.logic.diff.DiffResult;
 import cloud.foundry.cli.logic.diff.change.CfChange;
 import cloud.foundry.cli.logic.diff.change.container.CfContainerChange;
@@ -104,7 +104,7 @@ public class ApplyLogic {
             log.info("No changes detected, nothing to apply");
         } else {
             Flux<Void> spaceDevelopersRequests = Flux.just(spaceDevelopersChange)
-                    .flatMap(spaceDeveloperChange -> SpaceDevelopersRequestsPlaner
+                    .flatMap(spaceDeveloperChange -> SpaceDevelopersRequestsPlanner
                             .createSpaceDevelopersRequests(spaceDevelopersOperations, spaceDeveloperChange))
                     .onErrorContinue(log::warning);
             
@@ -145,10 +145,10 @@ public class ApplyLogic {
         if (allApplicationChanges == null || allApplicationChanges.isEmpty()) {
             log.info("No changes detected, nothing to apply");
         } else {
-            ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(applicationsOperations);
+            ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(applicationsOperations);
 
             Flux<Void> applicationRequests = Flux.fromIterable(allApplicationChanges.entrySet())
-                    .flatMap(appChangeEntry -> requestsPlaner.createApplyRequests(appChangeEntry.getKey(),
+                    .flatMap(appChangeEntry -> requestsPlanner.createApplyRequests(appChangeEntry.getKey(),
                             appChangeEntry.getValue()))
                     .onErrorContinue(log::warning);
 
@@ -187,7 +187,7 @@ public class ApplyLogic {
         log.info("Applying changes to applications");
         Flux<Void> serviceRequests = Flux.fromIterable(allServicesChanges.entrySet())
                 .flatMap( serviceChangeEntry ->
-                        ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+                        ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                                 serviceChangeEntry.getKey(),
                                 serviceChangeEntry.getValue()))
                 .onErrorContinue(log::warning);

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/ApplyLogic.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/ApplyLogic.java
@@ -86,29 +86,31 @@ public class ApplyLogic {
     public void applySpaceDevelopers(@Nonnull List<String> desiredSpaceDevelopers) {
         checkNotNull(desiredSpaceDevelopers);
 
-        log.info("Fetching information about space developers...");
+        log.info("Fetching space developers data");
         List<String> liveSpaceDevelopers = this.getLogic.getSpaceDevelopers(spaceDevelopersOperations);
-        log.info("Information fetched.");
+        log.verbose("Fetching space developers data completed");
 
         ConfigBean desiredSpaceDevelopersConfig = createConfigFromSpaceDevelopers(desiredSpaceDevelopers);
         ConfigBean liveSpaceDevelopersConfig = createConfigFromSpaceDevelopers(liveSpaceDevelopers);
 
         // compare entire configs as the diff wrapper is only suited for diff trees of these
-        log.info("Comparing the space developers...");
+        log.info("Diffing space developers");
         DiffResult wrappedDiff = this.diffLogic.createDiffResult(liveSpaceDevelopersConfig,
                 desiredSpaceDevelopersConfig);
-        log.info("Space developers compared.");
+        log.verbose("Diffing space developers completed");
 
         CfContainerChange spaceDevelopersChange = wrappedDiff.getSpaceDevelopersChange();
         if (spaceDevelopersChange == null) {
-            log.info("There is nothing to apply");
+            log.info("No changes detected, nothing to apply");
         } else {
             Flux<Void> spaceDevelopersRequests = Flux.just(spaceDevelopersChange)
                     .flatMap(spaceDeveloperChange -> SpaceDevelopersRequestsPlaner
                             .createSpaceDevelopersRequests(spaceDevelopersOperations, spaceDeveloperChange))
                     .onErrorContinue(log::warning);
-            log.info("Applying changes to space developers...");
+            
+            log.info("Applying changes to space developers");
             spaceDevelopersRequests.blockLast();
+            log.verbose("Changes to space developers applied");
         }
     }
 
@@ -125,23 +127,23 @@ public class ApplyLogic {
     public void applyApplications(@Nonnull Map<String, ApplicationBean> desiredApplications) {
         checkNotNull(desiredApplications);
 
-        log.info("Fetching information about applications...");
+        log.info("Fetching applications data");
         Map<String, ApplicationBean> liveApplications = this.getLogic.getApplications(applicationsOperations);
-        log.info("Information fetched.");
+        log.verbose("Fetched space developers data");
 
         // that way only the applications of the live system are compared in the diff
         ConfigBean desiredApplicationsConfig = createConfigFromApplications(desiredApplications);
         ConfigBean liveApplicationsConfig = createConfigFromApplications(liveApplications);
 
         // compare entire configs as the diff wrapper is only suited for diff trees of these
-        log.verbose("Comparing the applications...");
+        log.info("Diffing applications");
         DiffResult diffResult = this.diffLogic.createDiffResult(liveApplicationsConfig, desiredApplicationsConfig);
-        log.verbose("Applications compared.");
+        log.verbose("Diffing applications completed");
 
         Map<String, List<CfChange>> allApplicationChanges = diffResult.getApplicationChanges();
 
         if (allApplicationChanges == null || allApplicationChanges.isEmpty()) {
-            log.info("There are no differences to apply.");
+            log.info("No changes detected, nothing to apply");
         } else {
             ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(applicationsOperations);
 
@@ -150,9 +152,9 @@ public class ApplyLogic {
                             appChangeEntry.getValue()))
                     .onErrorContinue(log::warning);
 
-            log.info("Applying changes to applications...");
-
+            log.info("Applying changes to applications");
             applicationRequests.blockLast();
+            log.verbose("Changes to space developers applied");
         }
     }
 
@@ -166,21 +168,23 @@ public class ApplyLogic {
     public void applyServices(@Nonnull Map<String, ServiceBean> desiredServices) {
         checkNotNull(desiredServices);
 
-        log.info("Fetching information about services...");
+        log.info("Fetching services data");
         Map<String, ServiceBean> liveServices = this.getLogic.getServices(servicesOperations);
-        log.info("Information fetched.");
+        log.verbose("Fetching services data completed");
 
         // that way only the applications of the live system are compared in the diff
         ConfigBean desiredServicesConfig = createConfigFromServices(desiredServices);
         ConfigBean liveServicesConfig = createConfigFromServices(liveServices);
 
         // compare entire configs as the diff wrapper is only suited for diff trees of these
-        log.verbose("Comparing the services...");
+        log.info("Diffing services");
         DiffResult diffResult = this.diffLogic.createDiffResult(liveServicesConfig, desiredServicesConfig);
-        log.verbose("Services compared.");
+        log.verbose("Diffing space developers completed");
 
         Map<String, List<CfChange>> allServicesChanges = diffResult.getServiceChanges();
 
+        // TODO: find out how to detect "no changes" condition and log it accordingly
+        log.info("Applying changes to applications");
         Flux<Void> serviceRequests = Flux.fromIterable(allServicesChanges.entrySet())
                 .flatMap( serviceChangeEntry ->
                         ServiceRequestsPlaner.createApplyRequests(servicesOperations,
@@ -188,8 +192,7 @@ public class ApplyLogic {
                                 serviceChangeEntry.getValue()))
                 .onErrorContinue(log::warning);
         serviceRequests.blockLast();
-
-        log.info("Applying changes to services...");
+        log.verbose("Applying changes to applications completed");
     }
 
     /**
@@ -203,23 +206,25 @@ public class ApplyLogic {
         checkNotNull(desiredSpaceName);
 
         Mono<List<String>> getAllRequest = spaceOperations.getAll();
-        log.info("Fetching all space names...");
 
+        log.info("Fetching all spaces' names");
         List<String> spaceNames;
         try {
             spaceNames = getAllRequest.block();
         } catch (Exception e) {
             throw new GetException(e);
         }
+        log.verbose("Fetched spaces' names");
 
         if (!spaceNames.contains(desiredSpaceName)) {
-            log.info("Creating space with name:", desiredSpaceName);
+            log.info("Space", desiredSpaceName, "not found, creating");
             Mono<Void> createRequest = spaceOperations.create(desiredSpaceName);
             try {
                 createRequest.block();
             } catch (Exception e) {
                 throw new ApplyException(e);
             }
+            log.verbose("Space", desiredSpaceName, "created");
         } else {
             log.info("Space with name", desiredSpaceName, "already exists");
         }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/GetLogic.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/GetLogic.java
@@ -53,7 +53,7 @@ public class GetLogic {
         ConfigBean configBean = new ConfigBean();
         SpecBean specBean = new SpecBean();
         // start async querying of config data from the cloud foundry instance
-        log.debug("Start async querying of apps, services and space developers...");
+        log.debug("Fetching apps, services and space developers data");
         Flux<Object> getAllRequests = Flux.merge(apiVersion.doOnSuccess(configBean::setApiVersion),
                 spaceDevelopers.doOnSuccess(specBean::setSpaceDevelopers),
                 services.doOnSuccess(specBean::setServices),

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ApplicationRequestsPlaner.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ApplicationRequestsPlaner.java
@@ -124,7 +124,7 @@ public class ApplicationRequestsPlaner {
         List<Publisher<Void>> requests = new LinkedList<>();
 
         if (hasNewObject(changes)) {
-            log.debug("Add create app request for app: " + applicationName);
+            log.debug("Requesting creation of app", applicationName);
 
             ApplicationBean bean = (ApplicationBean) getChange(changes, change -> change instanceof CfNewObject)
                     .get()
@@ -132,11 +132,11 @@ public class ApplicationRequestsPlaner {
 
             return Flux.merge(this.appOperations.create(applicationName, bean, false));
         } else if (hasRemovedObject(changes)) {
-            log.debug("Add remove app request for app: " + applicationName);
+            log.debug("Requesting removal of app", applicationName);
 
             return Flux.merge(this.appOperations.remove(applicationName));
         } else if (hasFieldsThatRequireRestart(changes)) {
-            log.debug("Add redeploying update request for app: " + applicationName);
+            log.debug("Requesting redeployment/update of app", applicationName);
 
             for (CfChange change : changes) {
                 logChange(change);
@@ -145,7 +145,7 @@ public class ApplicationRequestsPlaner {
             ApplicationBean bean = (ApplicationBean) changes.get(0).getAffectedObject();
             return Flux.concat(appOperations.update(applicationName, bean, false));
         } else if (changes.size() > 0) {
-            log.debug("Add rolling update requests for app: " + applicationName);
+            log.debug("Requesting rolling update of app " + applicationName);
             requests.add(getScaleInstancesRequest(changes));
             requests.add(getChangedEnvironmentVariablesRequests(changes));
             requests.add(getChangedServicesRequests(changes));
@@ -178,18 +178,15 @@ public class ApplicationRequestsPlaner {
             logChange(servicesChange);
 
             for (CfContainerValueChanged valueChanged : servicesChange.getValueChangesBy(ChangeType.ADDED)) {
-                log.debug("Adding request to bind service",
-                        valueChanged.getValue(),
-                        "to application",
-                        applicationName);
+                log.debug("Requesting binding of service", valueChanged.getValue(), "to application", applicationName);
                 requests.add(this.appOperations.bindToService(applicationName, valueChanged.getValue()));
             }
 
             for (CfContainerValueChanged valueChanged : servicesChange.getValueChangesBy(ChangeType.REMOVED)) {
-                log.debug("Adding request to unbind service",
-                        valueChanged.getValue(),
-                        "from application",
-                        applicationName);
+                log.debug(
+                        "Requesting unbinding of service", valueChanged.getValue(),
+                        "from application", applicationName
+                );
                 requests.add(this.appOperations.unbindFromService(applicationName, valueChanged.getValue()));
             }
 
@@ -209,7 +206,7 @@ public class ApplicationRequestsPlaner {
             for (CfMapValueChanged valueChanged : enVarsChange.getChangedValues()) {
                 switch (valueChanged.getChangeType()) {
                     case ADDED:
-                        log.debug("Adding request to add environment variable",
+                        log.debug("Requesting addition of environment variable",
                                 valueChanged.getKey(),
                                 "with value",
                                 valueChanged.getValueAfter(),
@@ -220,20 +217,20 @@ public class ApplicationRequestsPlaner {
                                 valueChanged.getValueAfter()));
                         break;
                     case CHANGED:
-                        log.debug("Adding request to change environment variable",
+                        log.debug("Requesting change of environment variable",
                                 valueChanged.getKey(),
                                 "from value",
                                 valueChanged.getValueBefore(),
                                 "to value",
                                 valueChanged.getValueAfter(),
-                                "for  application",
+                                "for application",
                                 applicationName);
                         requests.add(this.appOperations.addEnvironmentVariable(applicationName,
                                 valueChanged.getKey(),
                                 valueChanged.getValueAfter()));
                         break;
                     case REMOVED:
-                        log.debug("Adding request to remove environment variable",
+                        log.debug("Requesting removal of environment variable",
                                 valueChanged.getKey(),
                                 "from application",
                                 applicationName);
@@ -241,7 +238,7 @@ public class ApplicationRequestsPlaner {
                                 valueChanged.getKey()));
                         break;
                     default:
-                        throw new AssertionError("Encountered an unknown change type");
+                        throw new AssertionError("Encountered unknown change type " + valueChanged.getChangeType());
                 }
             }
             return Flux.concat(requests);
@@ -260,7 +257,7 @@ public class ApplicationRequestsPlaner {
             logChange(routesChanges);
 
             for (CfContainerValueChanged valueChanged : routesChanges.getValueChangesBy(ChangeType.ADDED)) {
-                log.debug("Adding request to add route",
+                log.debug("Requesting addition of route",
                         valueChanged.getValue(),
                         "to application",
                         applicationName);
@@ -268,7 +265,7 @@ public class ApplicationRequestsPlaner {
             }
 
             for (CfContainerValueChanged valueChanged : routesChanges.getValueChangesBy(ChangeType.REMOVED)) {
-                log.debug("Adding request to remove route",
+                log.debug("Requesting removal of route",
                         valueChanged.getValue(),
                         "from application",
                         applicationName);
@@ -305,6 +302,6 @@ public class ApplicationRequestsPlaner {
     }
 
     private void logChange(CfChange change) {
-        log.debug("Property <" + change.getPropertyName() + "> for app <" + applicationName + "> will be updated.");
+        log.debug("Property", change.getPropertyName(), "for app", applicationName, "will be updated.");
     }
 }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ApplicationRequestsPlanner.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ApplicationRequestsPlanner.java
@@ -29,9 +29,9 @@ import java.util.function.Predicate;
  * This class is responsible to build the requests in the context of
  * applications according to the CfChanges.
  */
-public class ApplicationRequestsPlaner {
+public class ApplicationRequestsPlanner {
 
-    private static final Log log = Log.getLog(ApplicationRequestsPlaner.class);
+    private static final Log log = Log.getLog(ApplicationRequestsPlanner.class);
 
     private static final String META_FIELD_NAME = "meta";
     private static final String PATH_FIELD_NAME = "path";
@@ -93,7 +93,7 @@ public class ApplicationRequestsPlaner {
      *
      * @param appOperations the ApplicationOperations object used for
      */
-    public ApplicationRequestsPlaner(ApplicationsOperations appOperations) {
+    public ApplicationRequestsPlanner(ApplicationsOperations appOperations) {
         this.appOperations = appOperations;
     }
 

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/RequestsPlanner.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/RequestsPlanner.java
@@ -16,11 +16,11 @@ import java.util.List;
 
 
 /**
- * This is the super class of all request planer classes which are responsible to build the required requests
+ * This is the super class of all request planner classes which are responsible to build the required requests
  * for their operation domain according to the given CfChange objects.
  * The class does create the request tasks by implementing the {@link CfChangeVisitor} interface.
  */
-public abstract class RequestsPlaner implements CfChangeVisitor {
+public abstract class RequestsPlanner implements CfChangeVisitor {
 
     protected enum RequestType {
         NONE,
@@ -42,7 +42,7 @@ public abstract class RequestsPlaner implements CfChangeVisitor {
 
     private final List<Mono<Void>> requests;
 
-    protected RequestsPlaner() {
+    protected RequestsPlanner() {
         this.requests = new LinkedList<>();
         this.requestType = RequestType.NONE;
     }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ServiceRequestsPlaner.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ServiceRequestsPlaner.java
@@ -133,7 +133,7 @@ public class ServiceRequestsPlaner extends RequestsPlaner {
         }
 
         try {
-            log.info("Adding remove request for service " + serviceName);
+            log.info("Requesting removal of service", serviceName);
             this.addRequest(servicesOperations.remove(serviceName));
         } catch (UpdateException | NullPointerException e) {
             throw new ApplyException(e);

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ServiceRequestsPlanner.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/ServiceRequestsPlanner.java
@@ -23,14 +23,14 @@ import java.util.List;
  * according to the CfChanges. The class does create the request tasks by
  * implementing the {@link CfChangeVisitor} interface.
  */
-public class ServiceRequestsPlaner extends RequestsPlaner {
+public class ServiceRequestsPlanner extends RequestsPlanner {
 
-    private static final Log log = Log.getLog(ServiceRequestsPlaner.class);
+    private static final Log log = Log.getLog(ServiceRequestsPlanner.class);
 
     private final ServicesOperations servicesOperations;
     private final String serviceName;
 
-    private ServiceRequestsPlaner(ServicesOperations servicesOperations, String serviceName) {
+    private ServiceRequestsPlanner(ServicesOperations servicesOperations, String serviceName) {
         this.servicesOperations = servicesOperations;
         this.serviceName = serviceName;
     }
@@ -159,13 +159,13 @@ public class ServiceRequestsPlaner extends RequestsPlaner {
         checkNotNull(serviceName);
         checkNotNull(serviceChanges);
 
-        ServiceRequestsPlaner serviceRequestsPlaner = new ServiceRequestsPlaner(servicesOperations,
+        ServiceRequestsPlanner serviceRequestsPlanner = new ServiceRequestsPlanner(servicesOperations,
                 serviceName);
         for (CfChange applicationChange : serviceChanges) {
-            applicationChange.accept(serviceRequestsPlaner);
+            applicationChange.accept(serviceRequestsPlanner);
         }
 
-        return Flux.merge(serviceRequestsPlaner.getRequests());
+        return Flux.merge(serviceRequestsPlanner.getRequests());
     }
 
 }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/SpaceDevelopersRequestsPlanner.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/apply/SpaceDevelopersRequestsPlanner.java
@@ -15,9 +15,9 @@ import java.util.List;
 /**
  * This class is responsible to build the requests in the context of space developers according to the CfChanges.
  */
-public class SpaceDevelopersRequestsPlaner {
+public class SpaceDevelopersRequestsPlanner {
 
-    private static final Log log = Log.getLog(SpaceDevelopersRequestsPlaner.class);
+    private static final Log log = Log.getLog(SpaceDevelopersRequestsPlanner.class);
 
     /**
      * Creates the requests to assign/revoke space developer's permission.

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/diff/change/ChangeParser.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/diff/change/ChangeParser.java
@@ -50,7 +50,7 @@ public class ChangeParser {
             return parsers.get(change.getClass()).parse(change);
         }
 
-        log.debug("Change type " + change.getClass() + " is not supported for parsing. Ignoring it.");
+        log.debug("Ignoring unsupported change type", change.getClass());
         return Collections.emptyList();
     }
 

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/diff/change/parsing/ContainerChangeParsingStrategy.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/diff/change/parsing/ContainerChangeParsingStrategy.java
@@ -55,7 +55,7 @@ public class ContainerChangeParsingStrategy extends AbstractParsingStrategy {
             return new CfContainerValueChanged(((ValueRemoved) elementChange).getRemovedValue().toString(),
                     ChangeType.REMOVED);
         }
-        log.debug("List change type not supported: " + elementChange.getClass());
+        log.debug("Ignoring unsupported list change type", elementChange.getClass());
         return null;
     }
 }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/ApplicationsOperations.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/ApplicationsOperations.java
@@ -105,7 +105,8 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
 
         return this.cloudFoundryOperations.applications()
             .delete(request)
-            .doOnSuccess(aVoid -> log.info("App removed: ", applicationName))
+            .doOnSubscribe(aVoid -> log.info("Removing application", applicationName))
+            .doOnSuccess(aVoid -> log.verbose("Removing application", applicationName, "completed"))
             .onErrorStop();
     }
 
@@ -172,11 +173,11 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                         .applicationsV3()
                         .create(buildCreateApplicationRequest(spaceId, appName, bean))
                         .doOnSubscribe(subscription -> {
-                            log.debug("Create app:", appName);
-                            log.debug("Bean of the app:", bean);
-                            log.debug("Should the app start:", shouldStart);
+                            log.debug("Creating application", appName);
+                            log.debug("App's bean:", bean);
+                            log.debug("App should be started:", shouldStart);
                         })
-                        .doOnSuccess(aVoid -> log.info("App created:", appName))
+                        .doOnSuccess(aVoid -> log.info("Creating application", appName, "completed"))
                         .then())
                 .then(this.cloudFoundryOperations
                 .applications()
@@ -186,8 +187,8 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                         .noStart(!shouldStart)
                         .build())
                 .onErrorContinue(this::whenServiceNotFound, log::warning)
-                .doOnSubscribe(subscription -> log.debug("Pushing app manifest for:", appName))
-                .doOnSuccess(aVoid -> log.info("App manifest pushed for:", appName)));
+                .doOnSubscribe(subscription -> log.info("Pushing manifest for application", appName))
+                .doOnSuccess(aVoid -> log.verbose("Pushing manifest for application", appName, "completed")));
 
     }
 
@@ -290,10 +291,8 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                 .build();
 
         return this.cloudFoundryOperations.applications().rename(renameApplicationRequest)
-                .doOnSubscribe(aVoid -> {
-                    log.debug("Rename application:", currentName);
-                    log.debug("With new name:", newName); })
-                .doOnSuccess(aVoid -> log.info("Application renamed from", currentName, "to", newName));
+                .doOnSubscribe(aVoid -> log.info("Renaming application", currentName, "to", newName))
+                .doOnSuccess(aVoid -> log.verbose("Renaming of application", currentName, "to", newName, "completed"));
     }
 
     /**
@@ -319,11 +318,11 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
 
         return cloudFoundryOperations.applications().scale(scaleRequest)
                 .doOnSubscribe(aVoid -> {
-                    log.debug("Scale app:", applicationName);
-                    log.debug("With new disk limit:", diskLimit);
-                    log.debug("With new memory limit:", memoryLimit);
-                    log.debug("With new number of instances:", instances); })
-                .doOnSuccess(aVoid -> log.info("Application", applicationName, "was scaled"))
+                    log.info("Scaling application", applicationName);
+                    log.debug("New disk limit:", diskLimit);
+                    log.debug("New memory limit:", memoryLimit);
+                    log.debug("New number of instances:", instances); })
+                .doOnSuccess(aVoid -> log.verbose("Scaling application", applicationName, "completed"))
                 .onErrorStop()
                 .then();
     }
@@ -351,18 +350,20 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
 
         return cloudFoundryOperations.applications().setEnvironmentVariable(addEnvVarRequest)
                 .doOnSubscribe(aVoid -> {
-                    log.debug("Adding environment variable",
+                    log.info("Adding environment variable",
                             variableName,
                             "with value",
                             variableValue,
-                            "for app:",
-                            applicationName); })
-                .doOnSuccess(aVoid -> log.info("Environment variable",
+                            "to app",
+                            applicationName);
+                }).doOnSuccess(aVoid -> log.verbose("Adding environment variable",
                         variableName,
                         "with value",
                         variableValue ,
-                        "was added to the app",
-                        applicationName));
+                        "to app",
+                        applicationName,
+                        "completed")
+                );
     }
 
     /**
@@ -385,14 +386,15 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                 .build();
 
         return cloudFoundryOperations.applications().unsetEnvironmentVariable(removeEnvVarRequest)
-                .doOnSubscribe(aVoid -> log.debug("Removing environment variable",
+                .doOnSubscribe(aVoid -> log.info("Removing environment variable",
                         variableName,
-                        "for app:",
+                        "from app",
                         applicationName))
-                .doOnSuccess(aVoid -> log.info("Environment variable",
+                .doOnSuccess(aVoid -> log.verbose("Removing environment variable",
                         variableName,
-                            "was removed from the app",
-                        applicationName));
+                        "from app",
+                        applicationName,
+                        "completed"));
     }
 
     /**
@@ -414,11 +416,9 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                 .build();
 
         return cloudFoundryOperations.applications().setHealthCheck(setHealthCheckRequest)
-                .doOnSubscribe(aVoid -> {
-                    log.debug("Set health check type for app:", applicationName);
-                    log.debug("With health check type:", healthCheckType); })
-                .doOnSuccess(aVoid -> log.info("The health check type of the app", applicationName,
-                        "was set to", healthCheckType));
+                .doOnSubscribe(aVoid -> log.info(
+                        "Setting health check type for app", applicationName, "to", healthCheckType))
+                .doOnSuccess(aVoid -> log.verbose("Setting health check type for app", applicationName, "completed"));
     }
 
     /**
@@ -440,11 +440,9 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                 .build();
 
         return cloudFoundryOperations.services().bind(bindServiceRequest)
-                .doOnSuccess(aVoid -> {
-                    log.debug("Bind app:", applicationName);
-                    log.debug("To service:", serviceName); })
-                .doOnSuccess(aVoid -> log.info("Bound the app", applicationName,
-                        "to the service", serviceName));
+                .doOnSubscribe(aVoid -> log.info("Binding application", applicationName, "to service", serviceName))
+                .doOnSuccess(aVoid -> log.verbose(
+                        "Binding application", applicationName, "to service", serviceName, "completed"));
     }
 
     /**
@@ -466,11 +464,9 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                 .build();
 
         return cloudFoundryOperations.services().unbind(unbindServiceRequest)
-                .doOnSuccess(aVoid -> {
-                    log.debug("Unbind app:", applicationName);
-                    log.debug("From service:", serviceName); })
-                .doOnSuccess(aVoid -> log.info("Unbound the app", applicationName,
-                        "from the service", serviceName));
+                .doOnSubscribe(aVoid -> log.info("Unbinding app", applicationName, "from service", serviceName))
+                .doOnSuccess(aVoid -> log.verbose(
+                        "Unbinding app", applicationName, "from service", serviceName, "completed"));
     }
 
     /**
@@ -499,11 +495,9 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                         .host(decomposedRoute.getHost())
                         .path(decomposedRoute.getPath())
                         .build())
-                        .doOnSuccess(aVoid -> {
-                            log.debug("Add route:", route);
-                            log.debug("To app:", applicationName); })
-                        .doOnSuccess(aVoid -> log.info("Added the route", route,
-                                "to the application", applicationName)))
+                        .doOnSubscribe(aVoid -> log.info("Adding route", route, "to app", applicationName))
+                        .doOnSuccess(aVoid -> log.verbose(
+                                "Adding route", route, "to app", applicationName, "completed")))
                 .onErrorStop()
                 .then();
     }
@@ -534,11 +528,9 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                         .path(decomposedRoute.getPath())
                         .host(decomposedRoute.getHost())
                         .build())
-                        .doOnSuccess(aVoid -> {
-                            log.debug("Remove route:", route);
-                            log.debug("From app:", applicationName); })
-                        .doOnSuccess(aVoid -> log.info("Removed the route", route,
-                                "from the application", applicationName)));
+                        .doOnSubscribe(aVoid -> log.info("Removing route", route, "from app", applicationName))
+                        .doOnSuccess(aVoid -> log.info(
+                                "Removing route", route, "from app", applicationName, "completed")));
     }
 
     private DomainSummary createDomainSummary(Domain domain) {

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/ServicesOperations.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/ServicesOperations.java
@@ -82,10 +82,10 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
 
         return this.cloudFoundryOperations.services().createInstance(createServiceRequest)
                 .doOnSubscribe(aVoid -> {
-                    log.debug("Create service:", serviceInstanceName);
-                    log.debug("Bean of the service:", serviceBean);
+                    log.info("Creating service", serviceInstanceName);
+                    log.debug("Service bean:", serviceBean);
                 })
-                .doOnSuccess(aVoid -> log.info("Service created:", serviceInstanceName))
+                .doOnSuccess(aVoid -> log.verbose("Creating service", serviceInstanceName, "completed"))
                 .onErrorStop();
     }
 
@@ -110,11 +110,8 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
         //TODO: moove logs
         return this.cloudFoundryOperations.services()
                 .renameInstance(renameServiceInstanceRequest)
-                .doOnSubscribe(aVoid -> {
-                    log.debug("Rename service:", currentName);
-                    log.debug("With new name:", newName);
-                })
-                .doOnSuccess(aVoid -> log.info("Service renamed from", currentName, "to", newName))
+                .doOnSubscribe(aVoid -> log.info("Renaming service", currentName, "to", newName))
+                .doOnSuccess(aVoid -> log.verbose("Renaming service", currentName, "to", newName, "completed"))
                 .onErrorStop();
     }
 
@@ -141,10 +138,11 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
         return this.cloudFoundryOperations.services()
                 .updateInstance(updateServiceInstanceRequest)
                 .doOnSubscribe(subscription -> {
-                    log.debug("Update service Instance:", serviceInstanceName);
-                    log.debug("With the bean:", serviceBean);
+                    log.info("Updating tags and/or plan for service", serviceInstanceName);
+                    log.debug("Service bean:", serviceBean);
                 })
-                .doOnSuccess(aVoid -> log.info("Service tags and plan updated:", serviceInstanceName))
+                .doOnSuccess(aVoid -> log.verbose(
+                        "Updating tags and/or plan for service", serviceInstanceName, "completed"))
                 .onErrorStop();
     }
 
@@ -177,7 +175,8 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
     private Mono<Void> deleteServiceInstance(String serviceInstanceName) {
         return this.cloudFoundryOperations.services()
                 .deleteInstance(createDeleteServiceInstanceRequest(serviceInstanceName))
-                .doOnSuccess(aVoid -> log.info("Service " + serviceInstanceName + " has been removed."));
+                .doOnSubscribe(aVoid -> log.info("Removing service", serviceInstanceName))
+                .doOnSuccess(aVoid -> log.verbose("Removing service", serviceInstanceName, "completed"));
     }
 
     private DeleteServiceInstanceRequest createDeleteServiceInstanceRequest(String serviceInstanceName) {
@@ -207,9 +206,11 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
                         ? cloudFoundryOperations
                                 .services()
                                 .listServiceKeys(createListServiceKeysRequest(serviceInstanceName))
-                                .doOnComplete(() -> log.info("All service keys of service instance "
-                                        + serviceInstanceName + " have been deleted."))
-                        : Flux.empty()).doOnComplete(() -> log.verbose("There were no keys to delete."))
+                                .doOnSubscribe(aVoid -> log.info(
+                                        "Deleting all keys of service instance", serviceInstanceName))
+                                .doOnComplete(() -> log.verbose(
+                                        "Deleting all keys of service instance", serviceInstanceName, "completed"))
+                        : Flux.empty()).doOnComplete(() -> log.verbose("No keys found, nothing to delete"))
                 .flatMap(key -> doDeleteKey(serviceInstanceName, key));
     }
 
@@ -224,8 +225,10 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
         return this.cloudFoundryOperations
                 .services()
                 .deleteServiceKey(createDeleteServiceKeyRequest(serviceInstanceName, key))
-                .doOnSubscribe(subscription -> log.info("Deleting key " + key + " for " + serviceInstanceName))
-                .doOnSuccess(aVoid -> log.info("Deleted key " + key + " for service " + serviceInstanceName))
+                .doOnSubscribe(subscription -> log.info(
+                        "Deleting key " + key + " from service " + serviceInstanceName))
+                .doOnSuccess(aVoid -> log.verbose(
+                        "Deleting key " + key + " from service " + serviceInstanceName, "completed"))
                 .onErrorStop();
     }
 
@@ -249,15 +252,17 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
         return getServiceInstance(serviceInstanceName)
                 .flatMapIterable(serviceInstance -> {
                     if (serviceInstance.getApplications() == null || serviceInstance.getApplications().isEmpty()) {
-                        log.verbose("There is no application to unbind!");
+                        log.verbose("No applications bound to service", serviceInstanceName);
                         return Collections.emptyList();
                     } else {
                         return serviceInstance.getApplications();
                     }
                 })
                 .flatMap(appName -> unbindApp(serviceInstanceName, appName))
-                .doOnComplete(() -> log.info("All applications of service instance "
-                        + serviceInstanceName + " have been unbound."));
+                .doOnSubscribe(aVoid -> log.info(
+                        "Unbinding all applications from service instance", serviceInstanceName))
+                .doOnComplete(() -> log.verbose(
+                        "Unbinding all applications from service instance", serviceInstanceName, "completed"));
     }
 
     /**
@@ -275,10 +280,10 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
         return this.cloudFoundryOperations
                 .services()
                 .unbind(createUnbindServiceInstanceRequest(serviceInstanceName, applicationName))
-                .doOnSubscribe(subscription -> log.info("Unbind app " + applicationName +
-                        " for " + serviceInstanceName))
-                .doOnSuccess(subscription -> log.info("Unbound app " + applicationName +
-                        " for " + serviceInstanceName))
+                .doOnSubscribe(subscription -> log.info(
+                        "Unbinding app", applicationName, "from service", serviceInstanceName))
+                .doOnSuccess(subscription -> log.verbose(
+                        "Unbinding app", applicationName, "from service", serviceInstanceName, "completed"))
                 .onErrorStop();
     }
 
@@ -305,15 +310,16 @@ public class ServicesOperations extends AbstractOperations<DefaultCloudFoundryOp
                 .list(ListRoutesRequest.builder().build())
                 .filter(route -> route.getService() != null && route.getService().equals(serviceInstanceName))
                 .flatMap(this::doUnbindRoute)
-                .doOnComplete(() -> log.info("All routes to service instance "
-                        + serviceInstanceName + " have been unbound."));
+                .doOnSubscribe(aVoid -> log.info("Unbinding all routes from service instance", serviceInstanceName))
+                .doOnComplete(() -> log.verbose(
+                        "Unbinding all routes from service instance", serviceInstanceName, "completed"));
     }
 
     private Mono<Void> doUnbindRoute(Route route) {
         return this.cloudFoundryOperations
                 .services()
                 .unbindRoute(createRouteServiceInstanceRequest(route))
-                .doOnSubscribe(subscription -> log.info("unbind route " + route))
+                .doOnSubscribe(subscription -> log.debug("Unbinding route " + route))
                 .onErrorStop();
     }
 

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/SpaceDevelopersOperations.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/SpaceDevelopersOperations.java
@@ -79,8 +79,8 @@ public class SpaceDevelopersOperations extends AbstractOperations<DefaultCloudFo
         return cloudFoundryOperations.getCloudFoundryClient()
                 .spaces()
                 .associateDeveloperByUsername(request)
-                .doOnSubscribe(subscription -> log.debug("Assigning a space developer:", username))
-                .doOnSuccess(subscription -> log.info("Space developer: ", username, " was assigned"))
+                .doOnSubscribe(subscription -> log.debug("Assigning space developer", username))
+                .doOnSuccess(subscription -> log.verbose("Assigning space developer", username, "completed"))
                 .onErrorStop()
                 .then(Mono.empty());
     }
@@ -107,8 +107,8 @@ public class SpaceDevelopersOperations extends AbstractOperations<DefaultCloudFo
         return cloudFoundryOperations.getCloudFoundryClient()
                 .spaces()
                 .removeDeveloperByUsername(request)
-                .doOnSubscribe(subscription -> log.debug("Removing a space developer:", username))
-                .doOnSuccess(subscription -> log.info("Space developer: ", username, " was removed"))
+                .doOnSubscribe(subscription -> log.debug("Removing space developer", username))
+                .doOnSuccess(subscription -> log.verbose("Removing space developer", username, "completed"))
                 .onErrorStop()
                 .then(Mono.empty());
     }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/SpaceOperations.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/SpaceOperations.java
@@ -49,8 +49,8 @@ public class SpaceOperations extends AbstractOperations<DefaultCloudFoundryOpera
                 .name(spaceName)
                 .build();
         return this.cloudFoundryOperations.spaces().create(createSpaceRequest)
-                .doOnSubscribe(aVoid -> log.debug("Create space:", spaceName))
-                .doOnSuccess(aVoid -> log.info("Space created:", spaceName));
+                .doOnSubscribe(aVoid -> log.debug("Creating space", spaceName))
+                .doOnSuccess(aVoid -> log.verbose("Creating space", spaceName, "completed"));
     }
 
 }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/ApplyController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/ApplyController.java
@@ -40,7 +40,6 @@ public class ApplyController implements Callable<Integer> {
                     "in the given yaml file, but not in your cf instance, or revoke the space developer " +
                     "if its in the cf instance, but not in the yaml file.")
     static class ApplySpaceDevelopersCommand implements Callable<Integer> {
-
         private static final Log log = Log.getLog(ApplyApplicationCommand.class);
 
         @Mixin
@@ -51,13 +50,13 @@ public class ApplyController implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            log.info("Interpreting YAML file...");
+            log.info("Interpreting YAML file");
             ConfigBean desiredConfigBean = YamlMapper.loadBeanFromFile(yamlCommandOptions.getYamlFilePath(),
                     ConfigBean.class);
-            log.verbose("YAML file interpreted.");
+            log.verbose("Interpreting YAML file completed");
 
-            if(desiredConfigBean.getSpec() == null || desiredConfigBean.getSpec().getSpaceDevelopers() == null) {
-                log.info("No spaceDevelopers node specified in the yaml file. Nothing to apply...");
+            if (desiredConfigBean.getSpec() == null || desiredConfigBean.getSpec().getSpaceDevelopers() == null) {
+                log.info("No space developers data in YAML file, nothing to apply");
                 return 0;
             }
 
@@ -83,19 +82,18 @@ public class ApplyController implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
-
-            ApplyLogic applyLogic = new ApplyLogic(cfOperations);
-
-            log.info("Interpreting YAML file...");
+            log.info("Interpreting YAML file");
             ConfigBean desiredConfigBean = YamlMapper.loadBeanFromFile(yamlCommandOptions.getYamlFilePath(),
                     ConfigBean.class);
-            log.verbose("YAML file interpreted.");
+            log.verbose("Interpreting YAML file completed");
 
-            if(desiredConfigBean.getSpec() == null || desiredConfigBean.getSpec().getApps() == null) {
-                log.info("No apps node specified in the yaml file. Nothing to apply...");
+            if (desiredConfigBean.getSpec() == null || desiredConfigBean.getSpec().getApps() == null) {
+                log.info("No apps data in YAML file, nothing to apply");
                 return 0;
             }
+
+            DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
+            ApplyLogic applyLogic = new ApplyLogic(cfOperations);
 
             applyLogic.applyApplications(desiredConfigBean.getSpec().getApps());
 
@@ -121,13 +119,13 @@ public class ApplyController implements Callable<Integer> {
 
             ApplyLogic applyLogic = new ApplyLogic(cfOperations);
 
-            log.verbose("Interpreting YAML file...");
+            log.info("Interpreting YAML file");
             ConfigBean desiredConfigBean = YamlMapper.loadBeanFromFile(yamlCommandOptions.getYamlFilePath(),
                     ConfigBean.class);
-            log.verbose("YAML file interpreted.");
+            log.verbose("Interpreting YAML file completed");
 
-            if(desiredConfigBean.getSpec() == null || desiredConfigBean.getSpec().getServices() == null) {
-                log.info("No services node specified in the yaml file. Nothing to apply...");
+            if (desiredConfigBean.getSpec() == null || desiredConfigBean.getSpec().getServices() == null) {
+                log.info("No services data in YAML file, nothing to apply");
                 return 0;
             }
 
@@ -154,7 +152,7 @@ public class ApplyController implements Callable<Integer> {
             if (desiredSpace != null) {
                 applyLogic.applySpace(desiredSpace);
             } else {
-                log.info("No space specified.");
+                log.info("No space specified");
             }
 
             return 0;

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/BaseController.java
@@ -106,24 +106,24 @@ public class BaseController implements Callable<Integer> {
             } else if (ex instanceof UnsupportedOperationException) {
                 log.error("Operation not supported/implemented:", ex.getMessage());
             } else if (ex instanceof MissingCredentialsException) {
-                log.error("Missing credentials were detected:", ex.getMessage());
+                log.error("Credentials missing:", ex.getMessage());
             } else if (ex instanceof RefResolvingException) {
-                log.error("Failed to resolve " + RefResolver.REF_KEY + "-occurrences:", ex.getMessage());
+                log.error("Failed to resolve " + RefResolver.REF_KEY, "occurrences:", ex.getMessage());
             } else if (ex instanceof ConstructorException) {
-                log.error("Cannot interpret yaml contents:", ex.getMessage());
+                log.error("Failed to interpret YAML file contents:", ex.getMessage());
             } else if (ex instanceof ParserException || ex instanceof ScannerException) {
-                log.error("Cannot parse file contents:", ex.getMessage());
+                log.error("Failed to parse file contents:", ex.getMessage());
             } else if (ex instanceof DiffException) {
                 log.error("Unable to perform the diff:", ex.getMessage());
             } else if (ex instanceof ApplyException) {
-                log.error("An error occurred while processing the apply command:", ex.getMessage());
+                log.error("Apply command failed due to unexpected error", ex.getMessage());
             } else if (ex instanceof GetException) {
                 Throwable getExceptionCause = ex.getCause();
 
                 // the cases that are hard to identify are all wrapped in a GetException
                 if (getExceptionCause.getCause() instanceof UnknownHostException) {
                     // wrapped unknown host exceptions stand for unreachable hosts
-                    log.error("Unable to connect to the CF API host:", getExceptionCause.getMessage());
+                    log.error("Failed to connect to CF API: unknown host:", getExceptionCause.getMessage());
                 } else if (getExceptionCause instanceof IllegalArgumentException) {
                     // illegal argument exceptions seem to denote invalid organizations and spaces
                     log.error("Wrong arguments provided:", getExceptionCause.getMessage());
@@ -136,9 +136,9 @@ public class BaseController implements Callable<Integer> {
                     // it creates lambda class instances which are hard to test on...
                     // by these checks we can make sure, that the exception was caused by invalid credentials
                     log.error("Request to CF API failed: Invalid username or password " +
-                                "(your account might be locked due to too many login attempts with a wrong password)");
+                              "(your account might be locked due to too many login attempts with a wrong password)");
                 } else {
-                    log.error("An unexpected error occurred while processing the get command:", ex.getMessage());
+                    log.error("Get command failed due to unexpected error:", ex.getMessage());
                 }
 
             } else {
@@ -173,7 +173,7 @@ public class BaseController implements Callable<Integer> {
                 try {
                     fileHandler = new FileHandler(controller.logFile);
                 } catch (IOException e) {
-                    log.error("Could not open log file", controller.logFile);
+                    log.error("Failed to open log file", controller.logFile);
                     System.exit(1);
                 }
             }
@@ -188,11 +188,11 @@ public class BaseController implements Callable<Integer> {
             }
             if (controller.loggingOptions.isVerbose()) {
                 Log.setVerboseLogLevel();
-                log.verbose("enabling verbose logging");
+                log.verbose("Enabling verbose logging");
             }
             if (controller.loggingOptions.isDebug()) {
                 Log.setDebugLogLevel();
-                log.debug("enabling debug logging");
+                log.debug("Enabling debug logging");
             }
         }
 

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/DiffController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/DiffController.java
@@ -45,7 +45,6 @@ public class DiffController implements Callable<Integer> {
                 ConfigBean.class);
 
         log.debug("Desired config:", desiredConfigBean);
-        log.info("Fetching all information for target space...");
 
         SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
         ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
@@ -53,15 +52,21 @@ public class DiffController implements Callable<Integer> {
         ClientOperations clientOperations = new ClientOperations(cfOperations);
 
         GetLogic getLogic = new GetLogic();
+
+        log.info("Fetching all information for target space");
         ConfigBean currentConfigBean = getLogic.getAll(spaceDevelopersOperations, servicesOperations,
                 applicationsOperations, clientOperations, loginOptions);
+        log.verbose("Fetching all information for target space completed");
 
         log.debug("Current Config:", currentConfigBean);
-        log.info("Diffing ...");
 
         DiffLogic diffLogic = new DiffLogic();
+
+        log.info("Diffing");
         String output = diffLogic.createDiffOutput(currentConfigBean, desiredConfigBean);
-        log.debug("Diff string of config:", output);
+        log.verbose("Diffing completed");
+
+        log.debug("Diff string:", output);
 
         if (output.isEmpty()) {
             System.out.println(NO_DIFFERENCES);

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/DumpController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/DumpController.java
@@ -32,7 +32,7 @@ public class DumpController implements Callable<Integer> {
     public Integer call() throws Exception {
         String yamlFilePath = yamlCommandOptions.getYamlFilePath();
 
-        log.info("Reading and processing YAML the configuration file...");
+        log.info("Reading and processing YAML the configuration file");
         String resolvedConfig = YamlMapper.resolveYamlFile(yamlFilePath);
 
         // print the config before interpreting it, so that in cases of interpretation errors, the user still gets his

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/GetController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/GetController.java
@@ -32,15 +32,16 @@ public class GetController implements Callable<Integer> {
     public Integer call() {
         DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
         GetLogic getLogic = new GetLogic();
-        log.info("Fetching all information for target space...");
 
         SpaceDevelopersOperations spaceDevelopersOperations = new SpaceDevelopersOperations(cfOperations);
         ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
         ApplicationsOperations applicationsOperations = new ApplicationsOperations(cfOperations);
         ClientOperations clientOperations = new ClientOperations(cfOperations);
 
+        log.info("Fetching all information for target space");
         ConfigBean allInformation = getLogic.getAll(spaceDevelopersOperations, servicesOperations,
                 applicationsOperations, clientOperations, loginOptions);
+        log.verbose("Fetching all information for target space completed");
 
         System.out.println(YamlMapper.dump(allInformation));
         return 0;

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/RenameController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/RenameController.java
@@ -43,15 +43,16 @@ public class RenameController implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            log.info("Renaming application...");
-
             DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
             ApplicationsOperations applicationOperations = new ApplicationsOperations(cfOperations);
 
             RenameLogic renameLogic = new RenameLogic();
-            renameLogic.renameApplication(applicationOperations, newName, currentName);
 
-            log.info("Renamed the app from", currentName,"to", newName);
+
+            log.info("Renaming application from", currentName,"to", newName);
+            renameLogic.renameApplication(applicationOperations, newName, currentName);
+            log.verbose("Renaming application from", currentName,"to", newName, "completed");
+
             return 0;
         }
     }
@@ -72,15 +73,15 @@ public class RenameController implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            log.info("Renaming service...");
-
             DefaultCloudFoundryOperations cfOperations = CfOperationsCreator.createCfOperations(loginOptions);
             ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
 
             RenameLogic renameLogic = new RenameLogic();
-            renameLogic.renameService(servicesOperations, newName, currentName);
 
-            log.info("Renamed the service from", currentName,"to", newName);
+            log.info("Renaming service from", currentName,"to", newName);
+            renameLogic.renameService(servicesOperations, newName, currentName);
+            log.info("Renaming service from", currentName,"to", newName, "completed");
+
             return 0;
         }
     }

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/apply/ApplicationRequestPlannerTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/apply/ApplicationRequestPlannerTest.java
@@ -31,7 +31,7 @@ import reactor.test.StepVerifier;
 import java.util.Arrays;
 import java.util.LinkedList;
 
-class ApplicationRequestPlanerTest {
+class ApplicationRequestPlannerTest {
 
     @Test
     void applyTest_WithMultipleNewObject_AcceptMethodCallOnOnlyOne() {
@@ -53,10 +53,10 @@ class ApplicationRequestPlanerTest {
         cfChanges.add(newObject);
         cfChanges.add(newObject2);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());
@@ -73,11 +73,11 @@ class ApplicationRequestPlanerTest {
         CfNewObject newObject = new CfNewObject(serviceBeanMock, "", Arrays.asList("path"));
         cfChanges.add(newObject);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
         assertThrows(ApplyException.class,
-            () -> requestsPlaner.createApplyRequests(appName, cfChanges));
+            () -> requestsPlanner.createApplyRequests(appName, cfChanges));
     }
 
     @Test
@@ -93,10 +93,10 @@ class ApplicationRequestPlanerTest {
         Mono<Void> monoMock = Mono.just(voidMock);
         when(appOperations.create(appName, appBeanMock, false)).thenReturn(monoMock);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         verify(appOperations, times(1)).create(appName, appBeanMock, false);
@@ -117,11 +117,11 @@ class ApplicationRequestPlanerTest {
         cfChanges.add(newObject);
         doThrow(new CreationException("Test")).when(appOperations).create(appName, appBeanMock, false);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
         ApplyException applyException = assertThrows(ApplyException.class,
-            () -> requestsPlaner.createApplyRequests(appName,  cfChanges));
+            () -> requestsPlanner.createApplyRequests(appName,  cfChanges));
         // then
         assertThat(applyException.getCause(), is(instanceOf(CreationException.class)));
     }
@@ -140,10 +140,10 @@ class ApplicationRequestPlanerTest {
         Mono<Void> monoMock = Mono.just(voidMock);
         when(appOperations.remove(appName)).thenReturn(monoMock);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         verify(appOperations, times(1)).remove(appName);
@@ -163,11 +163,11 @@ class ApplicationRequestPlanerTest {
         CfRemovedObject removedObject = new CfRemovedObject(serviceBeanMock, "propertyName", Arrays.asList("path"));
         cfChanges.add(removedObject);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
         assertThrows(ApplyException.class,
-            () -> requestsPlaner.createApplyRequests(appName, cfChanges));
+            () -> requestsPlanner.createApplyRequests(appName, cfChanges));
     }
 
 
@@ -191,10 +191,10 @@ class ApplicationRequestPlanerTest {
                 "4");
         cfChanges.add(changedObject);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());
@@ -237,10 +237,10 @@ class ApplicationRequestPlanerTest {
 
         cfChanges.add(envVarsChange);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());
@@ -285,10 +285,10 @@ class ApplicationRequestPlanerTest {
 
         cfChanges.add(servicesChanges);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());
@@ -330,10 +330,10 @@ class ApplicationRequestPlanerTest {
 
         cfChanges.add(servicesChanges);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());
@@ -368,10 +368,10 @@ class ApplicationRequestPlanerTest {
 
         cfChanges.add(healthCheckTypeChange);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());
@@ -429,10 +429,10 @@ class ApplicationRequestPlanerTest {
 
         cfChanges.add(envVarsChange);
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());
@@ -451,10 +451,10 @@ class ApplicationRequestPlanerTest {
         String appName = "testApp";
         LinkedList<CfChange> cfChanges = new LinkedList<>();
 
-        ApplicationRequestsPlaner requestsPlaner = new ApplicationRequestsPlaner(appOperations);
+        ApplicationRequestsPlanner requestsPlanner = new ApplicationRequestsPlanner(appOperations);
 
         // when
-        Flux<Void> requests = requestsPlaner.createApplyRequests(appName, cfChanges);
+        Flux<Void> requests = requestsPlanner.createApplyRequests(appName, cfChanges);
 
         // then
         assertThat(requests, notNullValue());

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/apply/ServicesRequestsPlannerTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/apply/ServicesRequestsPlannerTest.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-public class ServicesRequestsPlanerTest {
+public class ServicesRequestsPlannerTest {
 
     @Test
     public void testCreateWithNewObjectSucceeds() {
@@ -48,7 +48,7 @@ public class ServicesRequestsPlanerTest {
         List<CfChange> cfChanges = new LinkedList<>();
         cfChanges.add(newChange);
         // when
-        Flux<Void> requests = ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+        Flux<Void> requests = ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                 "someservice",
                 cfChanges);
 
@@ -73,7 +73,7 @@ public class ServicesRequestsPlanerTest {
         cfChanges.add(newChange);
         // when
         assertThrows(ApplyException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations, "someservice", cfChanges));
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations, "someservice", cfChanges));
     }
 
     @Test
@@ -87,22 +87,22 @@ public class ServicesRequestsPlanerTest {
         cfChanges.add(newChange);
         // when
         assertThrows(IllegalArgumentException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations, "someservice", cfChanges));
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations, "someservice", cfChanges));
     }
 
     @Test
     public void testCreateOnNullArgumentsThrowsNullPointerException() {
         // when and then
         assertThrows(NullPointerException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(null,
+                () -> ServiceRequestsPlanner.createApplyRequests(null,
                         "someservice",
                         Collections.emptyList()));
         assertThrows(NullPointerException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(mock(ServicesOperations.class),
+                () -> ServiceRequestsPlanner.createApplyRequests(mock(ServicesOperations.class),
                         null,
                         Collections.emptyList()));
         assertThrows(NullPointerException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(mock(ServicesOperations.class),
+                () -> ServiceRequestsPlanner.createApplyRequests(mock(ServicesOperations.class),
                         "someservice",
                         null));
     }
@@ -118,7 +118,7 @@ public class ServicesRequestsPlanerTest {
 
         // when and then
         assertThrows(IllegalArgumentException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                         "someservice",
                         Arrays.asList(remove1, remove2)));
     }
@@ -132,7 +132,7 @@ public class ServicesRequestsPlanerTest {
 
         // when and then
         assertThrows(IllegalArgumentException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                         "someservice",
                         Arrays.asList(remove1)));
     }
@@ -147,7 +147,7 @@ public class ServicesRequestsPlanerTest {
 
         // when and then
         assertThrows(ApplyException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                         "someservice",
                         Arrays.asList(remove1)));
     }
@@ -161,7 +161,7 @@ public class ServicesRequestsPlanerTest {
         Mockito.when(servicesOperations.remove("someservice")).thenReturn(Mono.just(voidMock));
 
         // when
-        Flux<Void> requests = ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+        Flux<Void> requests = ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                 "someservice",
                 Arrays.asList(remove1));
 
@@ -184,7 +184,7 @@ public class ServicesRequestsPlanerTest {
 
         // when
         ApplyException exception = assertThrows(ApplyException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                         "someservice",
                         Arrays.asList(mapchange)));
 
@@ -206,7 +206,7 @@ public class ServicesRequestsPlanerTest {
         cfChanges.add(objectChanged);
 
         // when
-        Flux<Void> requests = ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+        Flux<Void> requests = ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                 serviceName,
                 cfChanges);
 
@@ -234,7 +234,7 @@ public class ServicesRequestsPlanerTest {
 
         // then - when
         assertThrows(ApplyException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations, serviceName, cfChanges));
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations, serviceName, cfChanges));
     }
 
     @Test
@@ -251,7 +251,7 @@ public class ServicesRequestsPlanerTest {
 
         // then - when
         assertThrows(IllegalArgumentException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations, serviceName, cfChanges));
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations, serviceName, cfChanges));
     }
 
     @Test
@@ -272,7 +272,7 @@ public class ServicesRequestsPlanerTest {
         cfChanges.add(newChange);
 
         // when
-        Flux<Void> requests = ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+        Flux<Void> requests = ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                 serviceName,
                 cfChanges);
 
@@ -301,7 +301,7 @@ public class ServicesRequestsPlanerTest {
 
         // then - when
         assertThrows(IllegalArgumentException.class,
-                () -> ServiceRequestsPlaner.createApplyRequests(servicesOperations, serviceName, cfChanges));
+                () -> ServiceRequestsPlanner.createApplyRequests(servicesOperations, serviceName, cfChanges));
     }
 
     @Test
@@ -327,7 +327,7 @@ public class ServicesRequestsPlanerTest {
         cfChanges.add(objectChanged);
 
         // when
-        Flux<Void> requests = ServiceRequestsPlaner.createApplyRequests(servicesOperations,
+        Flux<Void> requests = ServiceRequestsPlanner.createApplyRequests(servicesOperations,
                 serviceName,
                 cfChanges);
 

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/apply/SpaceDevelopersRequestsPlannerTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/apply/SpaceDevelopersRequestsPlannerTest.java
@@ -21,9 +21,9 @@ import reactor.test.StepVerifier;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test for {@link SpaceDevelopersRequestsPlaner}
+ * Test for {@link SpaceDevelopersRequestsPlanner}
  */
-public class SpaceDevelopersRequestsPlanerTest {
+public class SpaceDevelopersRequestsPlannerTest {
 
     @Test
     public void createSpaceDevelopersRequestsWithCfContainerChangeAcceptMethodCalled() {
@@ -61,7 +61,7 @@ public class SpaceDevelopersRequestsPlanerTest {
         when(mockSpaceDevelopersOperations.remove(removeUserName, spaceId)).thenReturn(removeMonoMock);
 
         // when
-        Flux<Void> requests = SpaceDevelopersRequestsPlaner
+        Flux<Void> requests = SpaceDevelopersRequestsPlanner
                 .createSpaceDevelopersRequests(mockSpaceDevelopersOperations, mockSpaceDevelopersChange);
 
         // then
@@ -83,7 +83,7 @@ public class SpaceDevelopersRequestsPlanerTest {
 
         // then - when
         assertThrows(NullPointerException.class,
-                () -> SpaceDevelopersRequestsPlaner
+                () -> SpaceDevelopersRequestsPlanner
                         .createSpaceDevelopersRequests(mockSpaceDevelopersOperations, spaceDevelopersChange));
     }
 
@@ -97,7 +97,7 @@ public class SpaceDevelopersRequestsPlanerTest {
 
         // then - when
         assertThrows(NullPointerException.class,
-                () -> SpaceDevelopersRequestsPlaner
+                () -> SpaceDevelopersRequestsPlanner
                         .createSpaceDevelopersRequests(mockSpaceDevelopersOperations, spaceDevelopersChange));
     }
 


### PR DESCRIPTION
This PR attempts to improve logging in the tool. It establishes a unified message and logging style by:

- rewriting most log messages' contents to have a consistent style, fix grammar and other language issues, and reduce the number of words
- fixing all log levels to a consistent scheme
- adding messages where needed
- adding log messages before *and* after every interaction with third party systems, with the messages before being *info* ones and the "on success" ones *verbose*