### PR TITLE
Make sure parent path can be calculated by cf-control

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/RefResolver.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/crosscutting/mapping/RefResolver.java
@@ -86,7 +86,7 @@ public class RefResolver implements YamlTreeVisitor {
         String filePath = extractFilePath(refValue);
         YamlPointer yamlPointer = extractYamlPointer(refValue);
 
-        String parentYamlFileDirectoryPath = Paths.get(parentYamlFilePath).getParent().toAbsolutePath().toString();
+        String parentYamlFileDirectoryPath = Paths.get(parentYamlFilePath).toAbsolutePath().getParent().toString();
         String absoluteFilePath;
 
         try {


### PR DESCRIPTION
Apparently, when passing a filename only, the platform-specific implementation in Paths isn't smart enough to assume e.g., a relative path like . as parent, and just returns a null pointer for paths like filename.yml. Since we're interested in the absolute path anyway, we can just fetch that before trying to query the parent path, and fix the bug that way.

In collaboration with @felix-oq