### PR TITLE
Consider target information from the yaml config when using get

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/GetLogic.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/logic/GetLogic.java
@@ -11,11 +11,7 @@ import cloud.foundry.cli.crosscutting.mapping.beans.SpecBean;
 import java.util.List;
 import java.util.Map;
 
-import cloud.foundry.cli.operations.ApplicationsOperations;
-import cloud.foundry.cli.operations.ServicesOperations;
-import cloud.foundry.cli.operations.SpaceDevelopersOperations;
-import cloud.foundry.cli.operations.ClientOperations;
-import cloud.foundry.cli.services.LoginCommandOptions;
+import cloud.foundry.cli.operations.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -32,19 +28,19 @@ public class GetLogic {
      * Gets all the necessary configuration-information from a cloud foundry
      * instance.
      *
-     * @param spaceDevelopersOperations operations for manipulating space developers on a cloud foundry instance.
-     * @param servicesOperations operations for querying and manipulating services on a cloud foundry instance.
-     * @param applicationsOperations operations for querying and manipulating applications on a cloud foundry instance.
-     * @param clientOperations operations to determine meta-information from a cloud foundry instance.
-     * @param loginOptions user provided Login-Options
-     * @return ConfigBean
+     * @param spaceDevelopersOperations operations for manipulating space developers on a cloud foundry instance
+     * @param servicesOperations operations for querying and manipulating services on a cloud foundry instance
+     * @param applicationsOperations operations for querying and manipulating applications on a cloud foundry instance
+     * @param clientOperations operations to determine meta-information from a cloud foundry instance
+     * @param targetOperations operations to determine target information from a cloud foundry instance
+     * @return a config bean instance holding all configurable information from a cloud foundry instance
      * @throws GetException if an error occurs during the information retrieving
      */
     public ConfigBean getAll(SpaceDevelopersOperations spaceDevelopersOperations,
                              ServicesOperations servicesOperations,
                              ApplicationsOperations applicationsOperations,
                              ClientOperations clientOperations,
-                             LoginCommandOptions loginOptions) {
+                             TargetOperations targetOperations) {
 
         Mono<String> apiVersion = clientOperations.determineApiVersion();
         Mono<List<String>> spaceDevelopers = spaceDevelopersOperations.getAll();
@@ -66,7 +62,7 @@ public class GetLogic {
         }
 
         configBean.setSpec(specBean);
-        configBean.setTarget(determineTarget(loginOptions));
+        configBean.setTarget(determineTarget(targetOperations));
         return configBean;
     }
 
@@ -122,14 +118,14 @@ public class GetLogic {
      * Determines the Target-Node configuration-information from a cloud foundry
      * instance.
      *
-     * @param loginOptions LoginCommandOptions
-     * @return TargetBean
+     * @param targetOperations the target operations that are used to gather the required information
+     * @return a target bean instance holding all target information
      */
-    private TargetBean determineTarget(LoginCommandOptions loginOptions) {
+    private TargetBean determineTarget(TargetOperations targetOperations) {
         TargetBean target = new TargetBean();
-        target.setEndpoint(loginOptions.getApiHost());
-        target.setOrg(loginOptions.getOrganization());
-        target.setSpace(loginOptions.getSpace());
+        target.setEndpoint(targetOperations.getApiHost());
+        target.setOrg(targetOperations.getOrganization());
+        target.setSpace(targetOperations.getSpace());
 
         return target;
     }

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/TargetOperations.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/TargetOperations.java
@@ -1,0 +1,41 @@
+package cloud.foundry.cli.operations;
+
+import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
+import org.cloudfoundry.reactor.DefaultConnectionContext;
+import org.cloudfoundry.reactor.client.ReactorCloudFoundryClient;
+
+/**
+ * Handles the operations for retrieving target information of a cloud foundry instance.
+ */
+public class TargetOperations extends AbstractOperations<DefaultCloudFoundryOperations> {
+
+    public TargetOperations(DefaultCloudFoundryOperations cloudFoundryOperations) {
+        super(cloudFoundryOperations);
+    }
+
+    /**
+     * @return the api host of the target cf instance
+     */
+    public String getApiHost() {
+        ReactorCloudFoundryClient reactorClient = (ReactorCloudFoundryClient) this.cloudFoundryOperations
+                .getCloudFoundryClient();
+        DefaultConnectionContext connectionContext = (DefaultConnectionContext) reactorClient.getConnectionContext();
+
+        return connectionContext.getApiHost();
+    }
+
+    /**
+     * @return the target organization of the cf instance
+     */
+    public String getOrganization() {
+        return this.cloudFoundryOperations.getOrganization();
+    }
+
+    /**
+     * @return the target space of the cf instance
+     */
+    public String getSpace() {
+        return this.cloudFoundryOperations.getSpace();
+    }
+
+}

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/DiffController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/DiffController.java
@@ -9,10 +9,7 @@ import cloud.foundry.cli.crosscutting.mapping.YamlMapper;
 import cloud.foundry.cli.crosscutting.mapping.beans.ConfigBean;
 import cloud.foundry.cli.logic.DiffLogic;
 import cloud.foundry.cli.logic.GetLogic;
-import cloud.foundry.cli.operations.ApplicationsOperations;
-import cloud.foundry.cli.operations.ClientOperations;
-import cloud.foundry.cli.operations.SpaceDevelopersOperations;
-import cloud.foundry.cli.operations.ServicesOperations;
+import cloud.foundry.cli.operations.*;
 import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
 
 import java.io.IOException;
@@ -53,12 +50,13 @@ public class DiffController implements Callable<Integer> {
         ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
         ApplicationsOperations applicationsOperations = new ApplicationsOperations(cfOperations);
         ClientOperations clientOperations = new ClientOperations(cfOperations);
+        TargetOperations targetOperations = new TargetOperations(cfOperations);
 
         GetLogic getLogic = new GetLogic();
 
         log.info("Fetching all information for target space");
         ConfigBean currentConfigBean = getLogic.getAll(spaceDevelopersOperations, servicesOperations,
-                applicationsOperations, clientOperations, loginOptions);
+                applicationsOperations, clientOperations, targetOperations);
         log.verbose("Fetching all information for target space completed");
 
         log.debug("Current Config:", currentConfigBean);

--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/GetController.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/services/GetController.java
@@ -5,10 +5,7 @@ import cloud.foundry.cli.crosscutting.mapping.beans.ConfigBean;
 import cloud.foundry.cli.crosscutting.mapping.CfOperationsCreator;
 import cloud.foundry.cli.crosscutting.mapping.YamlMapper;
 import cloud.foundry.cli.logic.GetLogic;
-import cloud.foundry.cli.operations.ApplicationsOperations;
-import cloud.foundry.cli.operations.ClientOperations;
-import cloud.foundry.cli.operations.ServicesOperations;
-import cloud.foundry.cli.operations.SpaceDevelopersOperations;
+import cloud.foundry.cli.operations.*;
 import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
@@ -39,10 +36,11 @@ public class GetController implements Callable<Integer> {
         ServicesOperations servicesOperations = new ServicesOperations(cfOperations);
         ApplicationsOperations applicationsOperations = new ApplicationsOperations(cfOperations);
         ClientOperations clientOperations = new ClientOperations(cfOperations);
+        TargetOperations targetOperations = new TargetOperations(cfOperations);
 
         log.info("Fetching all information for target space");
         ConfigBean allInformation = getLogic.getAll(spaceDevelopersOperations, servicesOperations,
-                applicationsOperations, clientOperations, requiredLoginCommandOptions);
+                applicationsOperations, clientOperations, targetOperations);
         log.verbose("Fetching all information for target space completed");
 
         System.out.println(YamlMapper.dump(allInformation));

--- a/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/GetLogicTest.java
+++ b/cloud.foundry.cli/src/test/java/cloud/foundry/cli/logic/GetLogicTest.java
@@ -15,10 +15,7 @@ import cloud.foundry.cli.crosscutting.mapping.beans.ApplicationManifestBean;
 import cloud.foundry.cli.crosscutting.mapping.beans.ConfigBean;
 
 import cloud.foundry.cli.crosscutting.mapping.beans.ServiceBean;
-import cloud.foundry.cli.operations.ApplicationsOperations;
-import cloud.foundry.cli.operations.ClientOperations;
-import cloud.foundry.cli.operations.ServicesOperations;
-import cloud.foundry.cli.operations.SpaceDevelopersOperations;
+import cloud.foundry.cli.operations.*;
 import cloud.foundry.cli.services.OptionalLoginCommandOptions;
 import org.cloudfoundry.client.v3.Metadata;
 import org.cloudfoundry.operations.applications.ApplicationHealthCheck;
@@ -61,11 +58,11 @@ public class GetLogicTest {
         when(mockApplications.getAll()).thenReturn(monoApplications);
 
         ClientOperations mockClientOperations = mockClientOperations();
-        OptionalLoginCommandOptions mockOptionalLoginCommandOptions = mockLoginCommandOptions();
+        TargetOperations mockTargetOperations = mockTargetOperations();
 
         // when
         ConfigBean configBean = getLogic.getAll(mockSpaceDevelopers, mockServices, mockApplications,
-                mockClientOperations, mockOptionalLoginCommandOptions);
+                mockClientOperations, mockTargetOperations);
 
         // then
         assertThat(configBean.getApiVersion(), is("API VERSION"));
@@ -86,13 +83,13 @@ public class GetLogicTest {
         ServicesOperations mockServices = mockServicesOperations();
         ApplicationsOperations mockApplications = mockApplicationOperations();
         ClientOperations mockClientOperations = mockClientOperations();
-        OptionalLoginCommandOptions mockOptionalLoginCommandOptions = mockLoginCommandOptions();
+        TargetOperations mockTargetOperations = mockTargetOperations();
 
         GetLogic getLogic = new GetLogic();
 
         // when
         ConfigBean configBean = getLogic.getAll(mockSpaceDevelopers, mockServices,
-                mockApplications, mockClientOperations, mockOptionalLoginCommandOptions);
+                mockApplications, mockClientOperations, mockTargetOperations);
 
         // then
         assertThat(configBean.getApiVersion(), is("API VERSION"));
@@ -309,13 +306,13 @@ public class GetLogicTest {
         return mockClientOperations;
     }
 
-    private OptionalLoginCommandOptions mockLoginCommandOptions() {
-        OptionalLoginCommandOptions mockOptionalLoginCommandOptions = mock(OptionalLoginCommandOptions.class);
-        when(mockOptionalLoginCommandOptions.getApiHost()).thenReturn("SOME API ENDPOINT");
-        when(mockOptionalLoginCommandOptions.getSpace()).thenReturn("development");
-        when(mockOptionalLoginCommandOptions.getOrganization()).thenReturn("cloud.foundry.cli");
+    private TargetOperations mockTargetOperations() {
+        TargetOperations mockTargetOperations = mock(TargetOperations.class);
+        when(mockTargetOperations.getApiHost()).thenReturn("SOME API ENDPOINT");
+        when(mockTargetOperations.getSpace()).thenReturn("development");
+        when(mockTargetOperations.getOrganization()).thenReturn("cloud.foundry.cli");
 
-        return mockOptionalLoginCommandOptions;
+        return mockTargetOperations;
     }
 
 }

--- a/cloud.foundry.cli/src/test/resources/demo/getAll.yml
+++ b/cloud.foundry.cli/src/test/resources/demo/getAll.yml
@@ -24,4 +24,4 @@ spec:
 target:
   endpoint: api.name.io
   org: org.name
-  space: spacename
+  space: development

--- a/cloud.foundry.cli/src/test/resources/demo/getAll.yml
+++ b/cloud.foundry.cli/src/test/resources/demo/getAll.yml
@@ -24,4 +24,4 @@ spec:
 target:
   endpoint: api.name.io
   org: org.name
-  space: development
+  space: spacename


### PR DESCRIPTION
This PR fixes the target information gathering from yaml configs when using the GetLogic class. Previously only the target information provided in the LoginCommandOptions was considered in the GetLogic class.