### PR TITLE
Remove unused dependency

### DIFF
--- a/cloud.foundry.cli/build.gradle
+++ b/cloud.foundry.cli/build.gradle
@@ -36,9 +36,6 @@ checkstyleTest {
 }
 
 dependencies {
-    // This dependency is exported to consumers, that is to say found on their compile classpath.
-    api 'org.apache.commons:commons-math3:3.6.1'
-
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:28.0-jre'
 


### PR DESCRIPTION
Removes the unused dependency `org.apache.commons:commons-math3:3.6.1`