### PR TITLE
Avoid errors in apply while removing service

### DIFF
--- a/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/ApplicationsOperations.java
+++ b/cloud.foundry.cli/src/main/java/cloud/foundry/cli/operations/ApplicationsOperations.java
@@ -482,9 +482,9 @@ public class ApplicationsOperations extends AbstractOperations<DefaultCloudFound
                 .doOnSubscribe(aVoid -> log.info("Unbinding app", applicationName, "from service", serviceName))
                 .doOnSuccess(aVoid -> log.verbose(
                         "Unbinding app", applicationName, "from service", serviceName, "completed"))
-                .onErrorStop()
-                .doOnError(this::whenServiceNotFound, (throwable) -> {
+                .onErrorResume(this::whenServiceNotFound, (throwable) -> {
                             log.warning("Could not unbind from service", serviceName + ":", throwable.getMessage());
+                            return Mono.empty();
                         });
     }
 


### PR DESCRIPTION
This should've been fixed before, but somehow the fix didn't make it into the codebase. This commit solves issues when a service is removed by the ServiceOperations (which unbinds them from the apps first). When the ApplicationsOperations then tries to unbind the service (because it doesn't exist any more), this operation can fail. This is a regular use case, and we only want to warn the user about this.